### PR TITLE
Fix client and server name case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ docs/
 
 # MacOS
 .DS_Store
+
+.idea/

--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -33,7 +33,7 @@ class ClientGenerator extends BaseGenerator {
 
   @override
   Future<void> generate() async {
-    final clientName = '${package.titleCase}Client';
+    final clientName = '${package.pascalCase}Client';
     final clientException = '${clientName}Exception';
 
     // Determine which security schemes are defined in API spec

--- a/lib/src/generators/server.dart
+++ b/lib/src/generators/server.dart
@@ -47,7 +47,7 @@ class ServerGenerator extends BaseGenerator {
 
   @override
   Future<void> generate() async {
-    final serverName = '${package.titleCase}Server';
+    final serverName = '${package.pascalCase}Server';
     final serverException = '${serverName}Exception';
 
     // Get all API paths


### PR DESCRIPTION
The generator was using "title case" for the name of the generated client and server. Which worked fine if the package name was a single word (e.g. `pinecone` -> `PineconeClient`), but it was breaking with multi-word names (e.g, `my_api` -> `My ApiClient`).

This PR changes the case conversion from "title case" to "pascal case".