### PR TITLE
Fix Dart classes not using pascal case

### DIFF
--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -115,14 +115,14 @@ class SchemaGenerator extends BaseGenerator {
           _writeEnumeration(name: name, schema: schema);
         },
         array: (schema) {
-          final iType = schema.items.ref ?? 'dynamic';
+          final iType = schema.items.toDartType();
           file.writeAsStringSync(
             'typedef $name = List<$iType>;',
             mode: FileMode.append,
           );
         },
         map: (schema) {
-          final vType = schema.valueSchema?.ref ?? 'dynamic';
+          final vType = schema.valueSchema?.toDartType() ?? 'dynamic';
           file.writeAsStringSync(
             'typedef $name = Map<String,$vType>;',
             mode: FileMode.append,
@@ -443,7 +443,7 @@ class SchemaGenerator extends BaseGenerator {
         }
 
         if (p.ref != null) {
-          c += "${p.ref} ${nullable ? '?' : ''} $name,\n\n";
+          c += "${p.toDartType()} ${nullable ? '?' : ''} $name,\n\n";
         } else if (unionSchemas.isNotEmpty) {
           final unionName = _unions.keys
                   .firstWhereOrNull((e) => _unions[e]!.equals(unionSchemas)) ??

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -284,18 +284,20 @@ class Schema with _$Schema {
             if (subSchemas.any((s) => !e.value.contains(s))) {
               continue;
             } else {
+              final type = e.key.pascalCase;
               if (s.nullable == true) {
-                return '${e.key}?';
+                return '$type?';
               } else {
-                return e.key;
+                return type;
               }
             }
           }
         } else if (s.ref != null) {
+          final type = s.ref!.pascalCase;
           if (s.nullable == true) {
-            return '${s.ref}?';
+            return '$type?';
           } else {
-            return s.ref!;
+            return type;
           }
         } else if (s.properties != null || s.anyOf != null) {
           return 'Map<String,dynamic>';


### PR DESCRIPTION
Some class names where not using the proper case when generated from a yaml file.

cc @walsha2 

**Example:**

Using the following spec to generate a server:
```yaml
openapi: "3.0.3"

info:
  title: knowledge-v1 API
  version: "1.0"

servers:
  - url: https://api.example.com

components:
  schemas:
    documents:
      type: array
      description: "List of documents"
      items:
        $ref: "#/components/schemas/document"
    document:
      type: object
      properties:
        id:
          type: string
          description: "Document ID"
        pageContent:
          type: string
          description: "Document content"
        metadata:
          $ref: "#/components/schemas/document_metadata"
      required:
        - id
        - pageContent
        - metadata
    document_metadata:
      type: object
      description: "Document metadata"
      properties:
        type:
          type: string
          description: "Document type"
        title:
          type: string
          description: "Document title"
        url:
          type: string
          description: "Document URL"
        locale:
          type: string
          description: "Document locale"
        updatedAt:
          type: string
          description: "Document last update date"
          format: date-time
      required:
        - type
        - title
        - url
        - locale
        - updatedAt
  responses:
    unauthorized:
      description: "Unauthorized: missing or invalid token"
    not_found:
      description: "User not found"
    internal_error:
      description: "Unexpected internal server error"

paths:
  /health/:
    get:
      description: "Health check"
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: string
  /knowledge/v1/find:
    parameters:
      - in: query
        name: q
        description: "Query"
        schema:
          type: string
      - in: query
        name: type
        description: "Document type"
        schema:
          type: string
          example: "faq"
      - in: query
        name: locale
        description: "Locale"
        schema:
          type: string
          example: "en_GB"
    get:
      description: "Find documents"
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/documents"
        "401":
          $ref: "#/components/responses/unauthorized"
        "500":
          $ref: "#/components/responses/internal_error"
```

This PR fixes the following issues:

`server.dart`:
<img width="342" alt="image" src="https://github.com/tazatechnology/openapi_spec/assets/6546265/2fcc2f99-a8e5-4e5c-a43c-e2842fc7fdca">

`schema/documets.dart`
<img width="363" alt="image" src="https://github.com/tazatechnology/openapi_spec/assets/6546265/7b3fa325-672e-4946-8402-578bb6e1b84b">

`schema/document.dart`
<img width="353" alt="image" src="https://github.com/tazatechnology/openapi_spec/assets/6546265/70fae9c9-87e8-4300-9166-86a2c579fa17">


