### PR TITLE
Fix invalid method name generated if path contains parameters

### DIFF
--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -491,7 +491,8 @@ class $clientName {
     if (operation.id != null) {
       methodName = operation.id!.camelCase;
     } else {
-      methodName = '${method.name}_$path'.camelCase;
+      final cleanPath = path.replaceAll(RegExp(r'[{}]'), '');
+      methodName = '${method.name}_$cleanPath'.camelCase;
     }
 
     // Allow user to override the default name

--- a/lib/src/generators/server.dart
+++ b/lib/src/generators/server.dart
@@ -301,7 +301,8 @@ class $serverName {
     if (operation.id != null) {
       methodName = operation.id!.camelCase;
     } else {
-      methodName = '${data.method.name}_${data.path}'.camelCase;
+      final cleanPath = data.path.replaceAll(RegExp(r'[<>]'), '');
+      methodName = '${data.method.name}_$cleanPath'.camelCase;
     }
 
     // Allow user to override the default name


### PR DESCRIPTION
If operation id is not specific, the method name is generated from the endpoint's path. However, if the path contains parameters, the generated name contains invalid characters (`{param}` in client, `<param>` in server).

This PR removes those invalid characters from the path before generating the method name.

Example:
```yaml
paths:
  /knowledge/v1/users/{userId}:
    parameters:
      - in: path
        name: userId
        description: "User ID"
        schema:
          type: string
        required: true
    get:
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                type: object
```

Generated name:
- Before: `getKnowledgeV1Users<userId>` / `getKnowledgeV1Users{userId}`
- Now: `getKnowledgeV1UsersUserId`

cc @walsha2 