### PR TITLE
Add support for patterns in path params

### DIFF
--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -491,7 +491,7 @@ class $clientName {
     if (operation.id != null) {
       methodName = operation.id!.camelCase;
     } else {
-      final cleanPath = path.replaceAll(RegExp(r'\W'), '');
+      final cleanPath = path.replaceAll(RegExp(r'\W'), '_');
       methodName = '${method.name}_$cleanPath'.camelCase;
     }
 

--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -491,7 +491,7 @@ class $clientName {
     if (operation.id != null) {
       methodName = operation.id!.camelCase;
     } else {
-      final cleanPath = path.replaceAll(RegExp(r'[{}]'), '');
+      final cleanPath = path.replaceAll(RegExp(r'\W'), '');
       methodName = '${method.name}_$cleanPath'.camelCase;
     }
 

--- a/lib/src/generators/server.dart
+++ b/lib/src/generators/server.dart
@@ -311,7 +311,7 @@ class $serverName {
     if (operation.id != null) {
       methodName = operation.id!.camelCase;
     } else {
-      final cleanPath = data.path.replaceAll(RegExp(r'\W'), '');
+      final cleanPath = data.path.replaceAll(RegExp(r'\W'), '_');
       methodName = '${data.method.name}_$cleanPath'.camelCase;
     }
 

--- a/lib/src/open_api/index.freezed.dart
+++ b/lib/src/open_api/index.freezed.dart
@@ -9324,6 +9324,7 @@ abstract class _$$_SchemaStringCopyWith<$Res> implements $SchemaCopyWith<$Res> {
       bool? nullable,
       @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       StringFormat? format,
+      String? pattern,
       String? example,
       @JsonKey(fromJson: _fromJsonInt) int? minLength,
       @JsonKey(fromJson: _fromJsonInt) int? maxLength,
@@ -9351,6 +9352,7 @@ class __$$_SchemaStringCopyWithImpl<$Res>
     Object? defaultValue = freezed,
     Object? nullable = freezed,
     Object? format = freezed,
+    Object? pattern = freezed,
     Object? example = freezed,
     Object? minLength = freezed,
     Object? maxLength = freezed,
@@ -9383,6 +9385,10 @@ class __$$_SchemaStringCopyWithImpl<$Res>
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
               as StringFormat?,
+      pattern: freezed == pattern
+          ? _value.pattern
+          : pattern // ignore: cast_nullable_to_non_nullable
+              as String?,
       example: freezed == example
           ? _value.example
           : example // ignore: cast_nullable_to_non_nullable
@@ -9433,6 +9439,7 @@ class _$_SchemaString extends _SchemaString {
       @JsonKey(name: 'default') this.defaultValue,
       this.nullable,
       @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue) this.format,
+      this.pattern,
       this.example,
       @JsonKey(fromJson: _fromJsonInt) this.minLength,
       @JsonKey(fromJson: _fromJsonInt) this.maxLength,
@@ -9461,6 +9468,8 @@ class _$_SchemaString extends _SchemaString {
   @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
   final StringFormat? format;
   @override
+  final String? pattern;
+  @override
   final String? example;
   @override
   @JsonKey(fromJson: _fromJsonInt)
@@ -9482,7 +9491,7 @@ class _$_SchemaString extends _SchemaString {
 
   @override
   String toString() {
-    return 'Schema.string(xml: $xml, title: $title, description: $description, defaultValue: $defaultValue, nullable: $nullable, format: $format, example: $example, minLength: $minLength, maxLength: $maxLength, exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum, ref: $ref)';
+    return 'Schema.string(xml: $xml, title: $title, description: $description, defaultValue: $defaultValue, nullable: $nullable, format: $format, pattern: $pattern, example: $example, minLength: $minLength, maxLength: $maxLength, exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum, ref: $ref)';
   }
 
   @override
@@ -9499,6 +9508,7 @@ class _$_SchemaString extends _SchemaString {
             (identical(other.nullable, nullable) ||
                 other.nullable == nullable) &&
             (identical(other.format, format) || other.format == format) &&
+            (identical(other.pattern, pattern) || other.pattern == pattern) &&
             (identical(other.example, example) || other.example == example) &&
             (identical(other.minLength, minLength) ||
                 other.minLength == minLength) &&
@@ -9521,6 +9531,7 @@ class _$_SchemaString extends _SchemaString {
       defaultValue,
       nullable,
       format,
+      pattern,
       example,
       minLength,
       maxLength,
@@ -9600,6 +9611,7 @@ abstract class _SchemaString extends Schema {
           final bool? nullable,
           @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
           final StringFormat? format,
+          final String? pattern,
           final String? example,
           @JsonKey(fromJson: _fromJsonInt) final int? minLength,
           @JsonKey(fromJson: _fromJsonInt) final int? maxLength,
@@ -9624,6 +9636,7 @@ abstract class _SchemaString extends Schema {
   bool? get nullable;
   @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
   StringFormat? get format;
+  String? get pattern;
   String? get example;
   @JsonKey(fromJson: _fromJsonInt)
   int? get minLength;

--- a/lib/src/open_api/index.g.dart
+++ b/lib/src/open_api/index.g.dart
@@ -997,6 +997,7 @@ _$_SchemaString _$$_SchemaStringFromJson(Map<String, dynamic> json) =>
       nullable: json['nullable'] as bool?,
       format: $enumDecodeNullable(_$StringFormatEnumMap, json['format'],
           unknownValue: JsonKey.nullForUndefinedEnumValue),
+      pattern: json['pattern'] as String?,
       example: json['example'] as String?,
       minLength: _fromJsonInt(json['minLength'] as num?),
       maxLength: _fromJsonInt(json['maxLength'] as num?),
@@ -1021,6 +1022,7 @@ Map<String, dynamic> _$$_SchemaStringToJson(_$_SchemaString instance) {
   writeNotNull('default', instance.defaultValue);
   writeNotNull('nullable', instance.nullable);
   writeNotNull('format', _$StringFormatEnumMap[instance.format]);
+  writeNotNull('pattern', instance.pattern);
   writeNotNull('example', instance.example);
   writeNotNull('minLength', instance.minLength);
   writeNotNull('maxLength', instance.maxLength);

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -87,6 +87,7 @@ class Schema with _$Schema {
     bool? nullable,
     @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
     StringFormat? format,
+    String? pattern,
     String? example,
     @JsonKey(fromJson: _fromJsonInt) int? minLength,
     @JsonKey(fromJson: _fromJsonInt) int? maxLength,


### PR DESCRIPTION
`shelf_router` supports defining path parameters with `<paramName|REGEXP>`, where `REGEXP` is a regular expression (leaving out `^` and `$`).

OpenAPI spec also supports [patterns](https://swagger.io/docs/specification/data-models/data-types/#pattern) for String types.

This PR adds support for converting path parameters with patterns in the OpenAPI spec to `shelf_router` path parameters.

For example:

```yaml
paths:
  /proxy/{endpoint}:
    parameters:
      - in: path
        name: endpoint
        schema:
          type: string
          pattern: '^.*$'
        required: true
    post:
      ...
```

will be converted to:

```dart
router.post('/proxy/<endpoint|.*>', (Request request, String endpoint) async {...}
```

which will match any path that starts with `/proxy/` and will pass the rest of the path as `endpoint` parameter.

cc @walsha2 