### PR TITLE
Fix static analysis warning in generated files

### DIFF
--- a/lib/src/generators/base.dart
+++ b/lib/src/generators/base.dart
@@ -38,6 +38,7 @@ abstract class BaseGenerator {
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 """;
     return header;
   }


### PR DESCRIPTION
pub.dev runs a static analysis against [lints_core](https://pub.dev/packages/lints) as part of its scoring system.
> See [pinecone package analysis results](https://pub.dev/packages/pinecone/score).

`freezed` package uses Json annotations in factory constructor parameters, which triggers an [invalid_annotation_target 
 warning](https://github.com/rrousselGit/freezed/issues/488):

<img width="1159" alt="image" src="https://github.com/tazatechnology/openapi_spec/assets/6546265/355bac2c-bac0-4f3c-9a61-5c15da7a1574">

Currently, the generator adds `ignore_for_file: type=lint` to the generated files, but that does not cover warnings. There is no generic way to [disable all lints and warnings](https://github.com/dart-lang/sdk/issues/53420), unfortunately. So, we need to specify the specific warnings we need to disable, in this case, `invalid_annotation_target`.

cc @walsha2 
