### PR TITLE
Improvements and fixes

### DIFF
--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -714,7 +714,7 @@ class $clientName {
         }
       }
       inputDescription.add(
-        "`request`: ${request.description ?? 'No description'}",
+        "`request`: ${request.description ?? rSchema?.description ?? 'No description'}",
       );
 
       body = 'body: request,';

--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -149,6 +149,7 @@ class $clientException implements io.HttpException {
     this.code,
     this.body,
   });
+  
   @override
   final String message;
   @override
@@ -180,31 +181,38 @@ class $clientException implements io.HttpException {
 // CLASS: $clientName
 // ==========================================
 
-/// Client for ${spec.info.title}
+/// Client for ${spec.info.title} (v.${spec.info.version})
 /// 
-/// `baseUrl`: Override baseUrl URL - else defaults to server url defined in spec
-/// 
-/// `client`: Override HTTP client to use for requests
+/// ${spec.info.description?.trim().replaceAll('\n', '\n/// ') ?? 'No description'}
 class $clientName {
+  /// Creates a new $clientName instance.
+  /// 
+  /// - [$clientName.baseUrl] Override base URL (default: server url defined in spec)
+  /// - [$clientName.headers] Global headers to be sent with every request
+  /// - [$clientName.client] Override HTTP client to use for requests
   $clientName({
     $authInputCode
-    String? baseUrl,
+    this.baseUrl,
+    this.headers = const {},
     http.Client? client,
   }) : assert(
           baseUrl == null || baseUrl.startsWith('http'),
           'baseUrl must start with http',
-        ) {
-    // Ensure trailing slash is removed from baseUrl
-    this.baseUrl = baseUrl?.replaceAll(RegExp(r'/\$'), '');
-    // Create a retry client
-    this.client = RetryClient(client ?? http.Client());
-  }
+        ),
+        assert(
+          baseUrl == null || !baseUrl.endsWith('/'),
+          'baseUrl must not end with /',
+        ),
+        client = RetryClient(client ?? http.Client());
 
-  /// User provided override for baseUrl URL
-  late final String? baseUrl;
+  /// Override base URL (default: server url defined in spec)
+  final String? baseUrl;
+  
+  /// Global headers to be sent with every request
+  final Map<String, String> headers;
 
   /// HTTP client for requests
-  late final http.Client client;
+  final http.Client client;
   
   ${authVariables.isEmpty ? '' : '/// Authentication related variables'}
   ${authVariables.join('\n')}
@@ -290,6 +298,9 @@ class $clientName {
     if (responseType.isNotEmpty){
       headers['${HttpHeaders.acceptHeader}'] = responseType;
     }
+    
+    // Add global headers
+    headers.addAll(this.headers);
 
     // Build the request object
     late http.Response response;

--- a/lib/src/generators/client.dart
+++ b/lib/src/generators/client.dart
@@ -223,8 +223,8 @@ class $clientName {
   /// Middleware for HTTP requests (user can override)
   ///
   /// The request can be of type [http.Request] or [http.MultipartRequest]
-  Future<http.BaseRequest> onRequest(http.BaseRequest request) async {
-    return request;
+  Future<http.BaseRequest> onRequest(http.BaseRequest request) {
+    return Future.value(request);
   }
 
   // ------------------------------------------
@@ -232,8 +232,8 @@ class $clientName {
   // ------------------------------------------
 
   /// Middleware for HTTP responses (user can override)
-  Future<http.Response> onResponse(http.Response response) async {
-    return response;
+  Future<http.Response> onResponse(http.Response response) {
+    return Future.value(response);
   }
 
   // ------------------------------------------

--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -557,7 +557,15 @@ class SchemaGenerator extends BaseGenerator {
 
         bool hasDefault = p.defaultValue != null;
         bool nullable = !hasDefault && !required || p.nullable == true;
-        String c = formatDescription(p.description);
+        String description = p.description?.trim() ?? '';
+
+        // Document possible values if no enum type defined
+        if (p.ref == null && p.values != null) {
+          description += '\n\nPossible values:\n'
+              '${p.values!.map((v) => '- `$v`\n').join()}';
+        }
+
+        String c = formatDescription(description);
 
         // Ensure default value is valid
         if (hasDefault && !(p.values?.contains(p.defaultValue) ?? true)) {

--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -386,8 +386,7 @@ class SchemaGenerator extends BaseGenerator {
 
     String formatDescription(String? description) {
       // Ensure description is free of new line characters
-      return '/// ${description?.trim().replaceAll('\n', '\n/// ') ??
-          'No Description'}\n';
+      return '/// ${description?.trim().replaceAll('\n', '\n/// ') ?? 'No Description'}\n';
     }
 
     (String, bool) propHeader(dynamic defaultValue, String? description) {
@@ -446,7 +445,7 @@ class SchemaGenerator extends BaseGenerator {
 
         if (p.ref != null) {
           c += p.toDartType();
-          if(nullable && !c.endsWith('?')){
+          if (nullable && !c.endsWith('?')) {
             c += '?'; // Only add '?' if the type doesn't have it already
           }
           c += " $name,\n\n";

--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -16,6 +16,7 @@ class SchemaGenerator extends BaseGenerator {
     file = File(p.join(schemaDirectory.path, 'schema.dart'));
     index = File(p.join(schemaDirectory.path, 'schema.dart'));
   }
+
   late File file;
   late final File index;
   late final Directory schemaDirectory;
@@ -292,7 +293,7 @@ class SchemaGenerator extends BaseGenerator {
     // CLASS: $name
     // ==========================================
     
-    /// ${s.description ?? 'No Description'}
+    /// ${s.description?.trim().replaceAll('\n', '\n/// ') ?? 'No Description'}
     @freezed
     class $name with _\$$name  {
       
@@ -383,10 +384,16 @@ class SchemaGenerator extends BaseGenerator {
 
     final jsonKey = "@JsonKey(name: '$jsonName') ";
 
+    String formatDescription(String? description) {
+      // Ensure description is free of new line characters
+      return '/// ${description?.trim().replaceAll('\n', '\n/// ') ??
+          'No Description'}\n';
+    }
+
     (String, bool) propHeader(dynamic defaultValue, String? description) {
       bool hasDefault = defaultValue != null;
       bool nullable = (!hasDefault && !required) || property.nullable == true;
-      String c = "/// ${description ?? 'No Description'} \n";
+      String c = formatDescription(description);
       if (jsonName != name) {
         c += jsonKey;
       }
@@ -403,12 +410,6 @@ class SchemaGenerator extends BaseGenerator {
       return (c, nullable);
     }
 
-    // Ensure description is free of new line characters
-    property = property.copyWith(
-      description:
-          property.description?.trim().replaceAll('\n', '\n/// ').trim(),
-    );
-
     property.map(
       object: (p) {
         p = p.dereference(components: spec.components?.schemas).maybeMap(
@@ -416,7 +417,7 @@ class SchemaGenerator extends BaseGenerator {
               orElse: () => p,
             );
         bool nullable = !required && p.defaultValue == null;
-        String c = "/// ${p.description ?? 'No Description'}\n";
+        String c = formatDescription(p.description);
 
         List<String> unionSchemas = [];
         if (p.anyOf != null) {
@@ -551,7 +552,7 @@ class SchemaGenerator extends BaseGenerator {
 
         bool hasDefault = p.defaultValue != null;
         bool nullable = !hasDefault && !required;
-        String c = "/// ${p.description ?? 'No Description'} \n";
+        String c = formatDescription(p.description);
 
         // Ensure default value is valid
         if (hasDefault && !(p.values?.contains(p.defaultValue) ?? true)) {
@@ -623,7 +624,7 @@ class SchemaGenerator extends BaseGenerator {
     // ENUM: $name
     // ==========================================
     
-    /// ${s.description ?? 'No Description'}
+    /// ${s.description?.trim().replaceAll('\n', '\n/// ') ?? 'No Description'}
     enum $name {
     """, mode: FileMode.append);
 
@@ -648,7 +649,7 @@ class SchemaGenerator extends BaseGenerator {
     required String def,
   }) {
     // Ensure description is free of new line characters
-    description = description?.replaceAll('\n', '\n/// ').trim();
+    description = description?.trim().replaceAll('\n', '\n/// ');
     file.writeAsStringSync("""
     // ==========================================
     // TYPE: $name

--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -416,7 +416,8 @@ class SchemaGenerator extends BaseGenerator {
               object: (s) => s,
               orElse: () => p,
             );
-        bool nullable = !required && p.defaultValue == null;
+        bool hasDefault = p.defaultValue != null;
+        bool nullable = !hasDefault && !required || p.nullable == true;
         String c = formatDescription(p.description);
 
         List<String> unionSchemas = [];
@@ -435,7 +436,7 @@ class SchemaGenerator extends BaseGenerator {
           c += jsonKey;
         }
 
-        if (p.defaultValue != null) {
+        if (hasDefault) {
           c += "@Default(${p.defaultValue}) ";
         }
 
@@ -444,7 +445,11 @@ class SchemaGenerator extends BaseGenerator {
         }
 
         if (p.ref != null) {
-          c += "${p.toDartType()} ${nullable ? '?' : ''} $name,\n\n";
+          c += p.toDartType();
+          if(nullable && !c.endsWith('?')){
+            c += '?'; // Only add '?' if the type doesn't have it already
+          }
+          c += " $name,\n\n";
         } else if (unionSchemas.isNotEmpty) {
           final unionName = _unions.keys
                   .firstWhereOrNull((e) => _unions[e]!.equals(unionSchemas)) ??
@@ -551,7 +556,7 @@ class SchemaGenerator extends BaseGenerator {
             );
 
         bool hasDefault = p.defaultValue != null;
-        bool nullable = !hasDefault && !required;
+        bool nullable = !hasDefault && !required || p.nullable == true;
         String c = formatDescription(p.description);
 
         // Ensure default value is valid

--- a/lib/src/open_api/index.dart
+++ b/lib/src/open_api/index.dart
@@ -49,8 +49,14 @@ bool _checkReferenceTypes(name, ref, self) {
   final sType = self.runtimeType.toString().replaceAll(r'_$_', '');
 
   if (ref.runtimeType != self.runtimeType) {
-    // Reference types can be different if the reference is a SchemaObject
-    if (self is _SchemaObject) {
+    if (ref is _SchemaMap && self is _SchemaObject) {
+      // Map is defined with typedef
+      return true;
+    } else if (ref is _SchemaArray && self is _SchemaMap) {
+      // Array is defined with typedef
+      return true;
+    } else if (self is _SchemaObject) {
+      // Reference types can be different if the reference is a SchemaObject
       return false;
     } else {
       throw Exception(

--- a/lib/src/open_api/index.freezed.dart
+++ b/lib/src/open_api/index.freezed.dart
@@ -10474,9 +10474,7 @@ class _$SchemaEnumImpl extends _SchemaEnum {
       @JsonKey(name: 'enum') final List<String>? values,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() this.ref,
       final String? $type})
-      : assert(
-            values == null || ref == null, 'Cannot define both values and ref'),
-        _values = values,
+      : _values = values,
         $type = $type ?? 'enumeration',
         super._();
 

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -236,7 +236,10 @@ class Schema with _$Schema {
       object: (s) {
         return (sRef as _SchemaObject).copyWith(
           ref: ref,
-          defaultValue: s.defaultValue,
+          title: s.title ?? sRef.title,
+          description: s.description ?? sRef.description,
+          defaultValue: s.defaultValue ?? sRef.defaultValue,
+          nullable: s.nullable ?? sRef.nullable,
         );
       },
       boolean: (s) {
@@ -258,6 +261,7 @@ class Schema with _$Schema {
           description: s.description ?? sRef.description,
           defaultValue: s.defaultValue ?? sRef.defaultValue,
           example: s.example ?? sRef.example,
+          nullable: s.nullable ?? sRef.nullable,
         );
       },
       array: (s) {

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -151,7 +151,6 @@ class Schema with _$Schema {
   // FACTORY: Schema.enumeration
   // ------------------------------------------
 
-  @Assert('values == null || ref == null', 'Cannot define both values and ref')
   const factory Schema.enumeration({
     String? title,
     String? description,

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -233,6 +233,15 @@ class Schema with _$Schema {
 
     return map(
       object: (s) {
+        // Handle List and Map defined as typedefs
+        if (sRef is _SchemaArray || sRef is _SchemaMap) {
+          return copyWith(
+            title: s.title ?? sRef.title,
+            description: s.description ?? sRef.description,
+            nullable: s.nullable ?? sRef.nullable,
+          );
+        }
+
         return (sRef as _SchemaObject).copyWith(
           ref: ref,
           title: s.title ?? sRef.title,
@@ -267,7 +276,9 @@ class Schema with _$Schema {
         return (sRef as _SchemaArray).copyWith(ref: ref);
       },
       map: (s) {
-        return (sRef as _SchemaMap).copyWith(ref: ref);
+        return (sRef as _SchemaMap).copyWith(
+          ref: ref,
+        );
       },
     );
   }

--- a/lib/src/open_api/spec.dart
+++ b/lib/src/open_api/spec.dart
@@ -528,7 +528,9 @@ Map<String, dynamic> _formatSpecFromJson(
     if (m.containsKey('type')) {
       if (m['type'] == 'string' && m.containsKey('enum')) {
         m['type'] = 'enumeration';
-      } else if (m['type'] == 'object' && m['additionalProperties'] != null) {
+      } else if (m['type'] == 'object' &&
+          m['additionalProperties'] != null &&
+          m['additionalProperties'] != false) {
         m['type'] = 'map';
       }
     } else if (m.containsKey('anyOf')) {


### PR DESCRIPTION
- Improve handling of descriptions in SchemaGenerator
  * Trims all descriptions
  * Replaces `\n` by `\n///` **after** trimming to avoid comments with an empty line at the end
- Use `Future.value` in middleware functions
  * Small performance improvement. Using `Future.value` Dart will create a new microtask event into the microtask queue instead of a new event into the event queue.
- Fix nullable property not taken into account in objects and enum
- Add possible values in enums descriptions
  * *Edit:* This is actually breaking the tests as we are modifying the spec content. Should I move this to the generator instead? 
- Use request schema description when null `requestBody` description
- Allow to define global headers included in every request

cc @walsha2 