### PR TITLE
Closes #13 Support anyOf with primitive types and arrays

### DIFF
--- a/lib/src/open_api/index.freezed.dart
+++ b/lib/src/open_api/index.freezed.dart
@@ -8540,7 +8540,7 @@ mixin _$Schema {
   String? get description => throw _privateConstructorUsedError;
 
   /// The default value code to place into `@Default()`
-  Object? get defaultValue => throw _privateConstructorUsedError;
+  dynamic get defaultValue => throw _privateConstructorUsedError;
 
   /// Reference to a schema definition
   @JsonKey(name: '\$ref')
@@ -8654,7 +8654,7 @@ abstract class _$$SchemaObjectImplCopyWith<$Res>
   $Res call(
       {String? title,
       String? description,
-      String? defaultValue,
+      dynamic defaultValue,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
       @_SchemaListConverter() List<Schema>? allOf,
       @_SchemaListConverter() List<Schema>? anyOf,
@@ -8706,7 +8706,7 @@ class __$$SchemaObjectImplCopyWithImpl<$Res>
       defaultValue: freezed == defaultValue
           ? _value.defaultValue
           : defaultValue // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as dynamic,
       ref: freezed == ref
           ? _value.ref
           : ref // ignore: cast_nullable_to_non_nullable
@@ -8820,7 +8820,7 @@ class _$SchemaObjectImpl extends _SchemaObject {
 
   /// The default value code to place into `@Default()`
   @override
-  final String? defaultValue;
+  final dynamic defaultValue;
 
   /// Reference to a schema definition
   @override
@@ -8918,8 +8918,8 @@ class _$SchemaObjectImpl extends _SchemaObject {
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
                 other.description == description) &&
-            (identical(other.defaultValue, defaultValue) ||
-                other.defaultValue == defaultValue) &&
+            const DeepCollectionEquality()
+                .equals(other.defaultValue, defaultValue) &&
             (identical(other.ref, ref) || other.ref == ref) &&
             const DeepCollectionEquality().equals(other._allOf, _allOf) &&
             const DeepCollectionEquality().equals(other._anyOf, _anyOf) &&
@@ -8941,7 +8941,7 @@ class _$SchemaObjectImpl extends _SchemaObject {
       runtimeType,
       title,
       description,
-      defaultValue,
+      const DeepCollectionEquality().hash(defaultValue),
       ref,
       const DeepCollectionEquality().hash(_allOf),
       const DeepCollectionEquality().hash(_anyOf),
@@ -9019,7 +9019,7 @@ abstract class _SchemaObject extends Schema {
   const factory _SchemaObject(
       {final String? title,
       final String? description,
-      final String? defaultValue,
+      final dynamic defaultValue,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref,
       @_SchemaListConverter() final List<Schema>? allOf,
       @_SchemaListConverter() final List<Schema>? anyOf,
@@ -9045,7 +9045,7 @@ abstract class _SchemaObject extends Schema {
   @override
 
   /// The default value code to place into `@Default()`
-  String? get defaultValue;
+  dynamic get defaultValue;
   @override
 
   /// Reference to a schema definition
@@ -10669,7 +10669,7 @@ abstract class _$$SchemaArrayImplCopyWith<$Res>
       String? description,
       @JsonKey(name: 'default') List<dynamic>? defaultValue,
       bool? nullable,
-      List<dynamic>? example,
+      dynamic example,
       @JsonKey(fromJson: _fromJsonInt) int? minItems,
       @JsonKey(fromJson: _fromJsonInt) int? maxItems,
       Schema items,
@@ -10723,9 +10723,9 @@ class __$$SchemaArrayImplCopyWithImpl<$Res>
           : nullable // ignore: cast_nullable_to_non_nullable
               as bool?,
       example: freezed == example
-          ? _value._example
+          ? _value.example
           : example // ignore: cast_nullable_to_non_nullable
-              as List<dynamic>?,
+              as dynamic,
       minItems: freezed == minItems
           ? _value.minItems
           : minItems // ignore: cast_nullable_to_non_nullable
@@ -10775,14 +10775,13 @@ class _$SchemaArrayImpl extends _SchemaArray {
       this.description,
       @JsonKey(name: 'default') final List<dynamic>? defaultValue,
       this.nullable,
-      final List<dynamic>? example,
+      this.example,
       @JsonKey(fromJson: _fromJsonInt) this.minItems,
       @JsonKey(fromJson: _fromJsonInt) this.maxItems,
       required this.items,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() this.ref,
       final String? $type})
       : _defaultValue = defaultValue,
-        _example = example,
         $type = $type ?? 'array',
         super._();
 
@@ -10808,16 +10807,8 @@ class _$SchemaArrayImpl extends _SchemaArray {
 
   @override
   final bool? nullable;
-  final List<dynamic>? _example;
   @override
-  List<dynamic>? get example {
-    final value = _example;
-    if (value == null) return null;
-    if (_example is EqualUnmodifiableListView) return _example;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
+  final dynamic example;
   @override
   @JsonKey(fromJson: _fromJsonInt)
   final int? minItems;
@@ -10852,7 +10843,7 @@ class _$SchemaArrayImpl extends _SchemaArray {
                 .equals(other._defaultValue, _defaultValue) &&
             (identical(other.nullable, nullable) ||
                 other.nullable == nullable) &&
-            const DeepCollectionEquality().equals(other._example, _example) &&
+            const DeepCollectionEquality().equals(other.example, example) &&
             (identical(other.minItems, minItems) ||
                 other.minItems == minItems) &&
             (identical(other.maxItems, maxItems) ||
@@ -10870,7 +10861,7 @@ class _$SchemaArrayImpl extends _SchemaArray {
       description,
       const DeepCollectionEquality().hash(_defaultValue),
       nullable,
-      const DeepCollectionEquality().hash(_example),
+      const DeepCollectionEquality().hash(example),
       minItems,
       maxItems,
       items,
@@ -10946,7 +10937,7 @@ abstract class _SchemaArray extends Schema {
           final String? description,
           @JsonKey(name: 'default') final List<dynamic>? defaultValue,
           final bool? nullable,
-          final List<dynamic>? example,
+          final dynamic example,
           @JsonKey(fromJson: _fromJsonInt) final int? minItems,
           @JsonKey(fromJson: _fromJsonInt) final int? maxItems,
           required final Schema items,
@@ -10967,7 +10958,7 @@ abstract class _SchemaArray extends Schema {
   List<dynamic>? get defaultValue;
   @override
   bool? get nullable;
-  List<dynamic>? get example;
+  dynamic get example;
   @JsonKey(fromJson: _fromJsonInt)
   int? get minItems;
   @JsonKey(fromJson: _fromJsonInt)

--- a/lib/src/open_api/index.g.dart
+++ b/lib/src/open_api/index.g.dart
@@ -908,7 +908,7 @@ _$SchemaObjectImpl _$$SchemaObjectImplFromJson(Map<String, dynamic> json) =>
     _$SchemaObjectImpl(
       title: json['title'] as String?,
       description: json['description'] as String?,
-      defaultValue: json['defaultValue'] as String?,
+      defaultValue: json['defaultValue'],
       ref: const _SchemaRefConverter().fromJson(json[r'$ref'] as String?),
       allOf: _$JsonConverterFromJson<List<dynamic>, List<Schema>>(
           json['allOf'], const _SchemaListConverter().fromJson),
@@ -1208,7 +1208,7 @@ _$SchemaArrayImpl _$$SchemaArrayImplFromJson(Map<String, dynamic> json) =>
       description: json['description'] as String?,
       defaultValue: json['default'] as List<dynamic>?,
       nullable: json['nullable'] as bool?,
-      example: json['example'] as List<dynamic>?,
+      example: json['example'],
       minItems: _fromJsonInt(json['minItems']),
       maxItems: _fromJsonInt(json['maxItems']),
       items: Schema.fromJson(json['items'] as Map<String, dynamic>),

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -13,6 +13,21 @@ int? _fromJsonInt(dynamic jsonValue) {
 double? _fromJsonDouble(num? jsonValue) => jsonValue?.toDouble();
 
 // ==========================================
+// ENUM: SchemaType
+// ==========================================
+
+enum SchemaType {
+  object,
+  boolean,
+  string,
+  integer,
+  number,
+  enumeration,
+  array,
+  map,
+}
+
+// ==========================================
 // CLASS: Schema
 // ==========================================
 
@@ -33,7 +48,7 @@ class Schema with _$Schema {
     String? description,
 
     /// The default value code to place into `@Default()`
-    String? defaultValue,
+    dynamic defaultValue,
 
     /// Reference to a schema definition
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
@@ -67,6 +82,20 @@ class Schema with _$Schema {
     /// Adds additional metadata to describe the XML representation of this property.
     Xml? xml,
   }) = _SchemaObject;
+
+  /// Get the schema type based on the union type
+  SchemaType get type {
+    return map(
+      object: (_) => SchemaType.object,
+      boolean: (_) => SchemaType.boolean,
+      string: (_) => SchemaType.string,
+      integer: (_) => SchemaType.integer,
+      number: (_) => SchemaType.number,
+      enumeration: (_) => SchemaType.enumeration,
+      array: (_) => SchemaType.array,
+      map: (_) => SchemaType.map,
+    );
+  }
 
   // ------------------------------------------
   // FACTORY: Schema.boolean
@@ -173,7 +202,7 @@ class Schema with _$Schema {
     String? description,
     @JsonKey(name: 'default') List? defaultValue,
     bool? nullable,
-    List? example,
+    dynamic example,
     @JsonKey(fromJson: _fromJsonInt) int? minItems,
     @JsonKey(fromJson: _fromJsonInt) int? maxItems,
     required Schema items,


### PR DESCRIPTION
## Overview

@davidmigloz this is mostly working. A lot of it builds off of the work done in recent PRs. There might be some edge cases that need to be accounted for, but that can come later. I wanted to get this in for testing and make changes later.

I spot checked most of the OpenAI client and schema code and it looks great. Captures the union types and nuances without the user needing to hand modify the schema.

Continuing with the `CreateCompletionRequest` example from #13 because that is indeed quite a complected request model with several nested types, unions, and enums. All of it gets generated to the same file which makes it easy to trace.

```dart
CreateCompletionRequest c;

c = CreateCompletionRequest(
  model: UnionCreateCompletionRequestModel.enumeration(
    CreateCompletionRequestModelEnum.babbage002,
  ),
  prompt: UnionCreateCompletionRequestPrompt.string(
    'Hello world',
  ),
);

print(c.toJson());
```

```json
{
  "model": "babbage-002",
  "prompt": "Hello world",
  "best_of": 1,
  "echo": false,
  "frequency_penalty": 0,
  "max_tokens": 16,
  "n": 1,
  "presence_penalty": 0,
  "stream": false,
  "temperature": 1,
  "top_p": 1
}
```

-----------


```dart
c = CreateCompletionRequest(
  model: UnionCreateCompletionRequestModel.string('custom-model'),
  prompt: UnionCreateCompletionRequestPrompt.arrayInteger(
    [1, 2, 3],
  ),
);
```

```json
{
  "model": "custom-model",
  "prompt": [1, 2, 3],
  "best_of": 1,
  "echo": false,
  "frequency_penalty": 0,
  "max_tokens": 16,
  "n": 1,
  "presence_penalty": 0,
  "stream": false,
  "temperature": 1,
  "top_p": 1
}
```

-----------

```dart
c = CreateCompletionRequest(
  model: UnionCreateCompletionRequestModel.string('custom-model'),
  prompt: UnionCreateCompletionRequestPrompt.array([
    [1, 2, 3],
    [4, 5, 6]
  ]),
);
```

```json
{
  "model": "custom-model",
  "prompt": [[1, 2, 3], [4, 5, 6]],
  "best_of": 1,
  "echo": false,
  "frequency_penalty": 0,
  "max_tokens": 16,
  "n": 1,
  "presence_penalty": 0,
  "stream": false,
  "temperature": 1,
  "top_p": 1
}
```
-----------

```dart
c = CreateCompletionRequest(
  model: UnionCreateCompletionRequestModel.string('custom-model'),
  prompt: UnionCreateCompletionRequestPrompt.arrayString(['hello', 'world']),
);
```

```json
{
  "model": "custom-model",
  "prompt": [
    "hello",
    "world"
  ],
  "best_of": 1,
  "echo": false,
  "frequency_penalty": 0,
  "max_tokens": 16,
  "n": 1,
  "presence_penalty": 0,
  "stream": false,
  "temperature": 1,
  "top_p": 1
}
```

## Raw Schema

https://github.com/tazatechnology/openapi_spec/blob/46e1989944b7fdff6c2e9a579f2d609b6460a15a/test/openai/openai.yaml#L2452-L2644

## Dart Code

```dart
// coverage:ignore-file
// GENERATED CODE - DO NOT MODIFY BY HAND
// ignore_for_file: type=lint
// ignore_for_file: invalid_annotation_target
part of openai_schema;

// ==========================================
// CLASS: CreateCompletionRequest
// ==========================================

/// No Description
@freezed
class CreateCompletionRequest with _$CreateCompletionRequest {
  const CreateCompletionRequest._();

  /// Factory constructor for CreateCompletionRequest
  const factory CreateCompletionRequest({
    /// ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.
    @_UnionCreateCompletionRequestModelConverter()
    required UnionCreateCompletionRequestModel model,

    /// The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
    ///
    /// Note that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the model will generate as if from the beginning of a new document.
    @_UnionCreateCompletionRequestPromptConverter()
    required UnionCreateCompletionRequestPrompt? prompt,

    /// Generates `best_of` completions server-side and returns the "best" (the one with the highest log probability per token). Results cannot be streamed.
    ///
    /// When used with `n`, `best_of` controls the number of candidate completions and `n` specifies how many to return – `best_of` must be greater than `n`.
    ///
    /// **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
    @JsonKey(name: 'best_of', includeIfNull: false) @Default(1) int? bestOf,

    /// Echo back the prompt in addition to the completion
    @JsonKey(includeIfNull: false) @Default(false) bool? echo,

    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
    ///
    /// [See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)
    @JsonKey(name: 'frequency_penalty', includeIfNull: false)
    @Default(0.0)
    double? frequencyPenalty,

    /// Modify the likelihood of specified tokens appearing in the completion.
    ///
    /// Accepts a json object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) (which works for both GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
    ///
    /// As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token from being generated.
    @JsonKey(name: 'logit_bias', includeIfNull: false)
    Map<String, int>? logitBias,

    /// Include the log probabilities on the `logprobs` most likely tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.
    ///
    /// The maximum value for `logprobs` is 5.
    @JsonKey(includeIfNull: false) int? logprobs,

    /// The maximum number of [tokens](/tokenizer) to generate in the completion.
    ///
    /// The token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
    @JsonKey(name: 'max_tokens', includeIfNull: false)
    @Default(16)
    int? maxTokens,

    /// How many completions to generate for each prompt.
    ///
    /// **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
    @JsonKey(includeIfNull: false) @Default(1) int? n,

    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
    ///
    /// [See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)
    @JsonKey(name: 'presence_penalty', includeIfNull: false)
    @Default(0.0)
    double? presencePenalty,

    /// Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
    @_UnionCreateCompletionRequestStopConverter()
    @JsonKey(includeIfNull: false)
    UnionCreateCompletionRequestStop? stop,

    /// Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
    @JsonKey(includeIfNull: false) @Default(false) bool? stream,

    /// The suffix that comes after a completion of inserted text.
    @JsonKey(includeIfNull: false) String? suffix,

    /// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
    ///
    /// We generally recommend altering this or `top_p` but not both.
    @JsonKey(includeIfNull: false) @Default(1.0) double? temperature,

    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
    ///
    /// We generally recommend altering this or `temperature` but not both.
    @JsonKey(name: 'top_p', includeIfNull: false) @Default(1.0) double? topP,

    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).
    @JsonKey(includeIfNull: false) String? user,
  }) = _CreateCompletionRequest;

  /// Object construction from a JSON representation
  factory CreateCompletionRequest.fromJson(Map<String, dynamic> json) =>
      _$CreateCompletionRequestFromJson(json);

  /// List of all property names of schema
  static const List<String> propertyNames = [
    'model',
    'prompt',
    'best_of',
    'echo',
    'frequency_penalty',
    'logit_bias',
    'logprobs',
    'max_tokens',
    'n',
    'presence_penalty',
    'stop',
    'stream',
    'suffix',
    'temperature',
    'top_p',
    'user'
  ];

  /// Validation constants
  static const bestOfDefaultValue = 1;
  static const bestOfMinValue = 0;
  static const bestOfMaxValue = 20;
  static const frequencyPenaltyDefaultValue = 0.0;
  static const frequencyPenaltyMinValue = -2.0;
  static const frequencyPenaltyMaxValue = 2.0;
  static const logprobsMinValue = 0;
  static const logprobsMaxValue = 5;
  static const maxTokensDefaultValue = 16;
  static const maxTokensMinValue = 0;
  static const nDefaultValue = 1;
  static const nMinValue = 1;
  static const nMaxValue = 128;
  static const presencePenaltyDefaultValue = 0.0;
  static const presencePenaltyMinValue = -2.0;
  static const presencePenaltyMaxValue = 2.0;
  static const temperatureDefaultValue = 1.0;
  static const temperatureMinValue = 0.0;
  static const temperatureMaxValue = 2.0;
  static const topPDefaultValue = 1.0;
  static const topPMinValue = 0.0;
  static const topPMaxValue = 1.0;

  /// Perform validations on the schema property values
  String? validateSchema() {
    if (bestOf != null && bestOf! < bestOfMinValue) {
      return "The value of 'bestOf' cannot be < $bestOfMinValue";
    }
    if (bestOf != null && bestOf! > bestOfMaxValue) {
      return "The value of 'bestOf' cannot be > $bestOfMaxValue";
    }
    if (frequencyPenalty != null &&
        frequencyPenalty! < frequencyPenaltyMinValue) {
      return "The value of 'frequencyPenalty' cannot be < $frequencyPenaltyMinValue";
    }
    if (frequencyPenalty != null &&
        frequencyPenalty! > frequencyPenaltyMaxValue) {
      return "The value of 'frequencyPenalty' cannot be > $frequencyPenaltyMaxValue";
    }
    if (logprobs != null && logprobs! < logprobsMinValue) {
      return "The value of 'logprobs' cannot be < $logprobsMinValue";
    }
    if (logprobs != null && logprobs! > logprobsMaxValue) {
      return "The value of 'logprobs' cannot be > $logprobsMaxValue";
    }
    if (maxTokens != null && maxTokens! < maxTokensMinValue) {
      return "The value of 'maxTokens' cannot be < $maxTokensMinValue";
    }
    if (n != null && n! < nMinValue) {
      return "The value of 'n' cannot be < $nMinValue";
    }
    if (n != null && n! > nMaxValue) {
      return "The value of 'n' cannot be > $nMaxValue";
    }
    if (presencePenalty != null && presencePenalty! < presencePenaltyMinValue) {
      return "The value of 'presencePenalty' cannot be < $presencePenaltyMinValue";
    }
    if (presencePenalty != null && presencePenalty! > presencePenaltyMaxValue) {
      return "The value of 'presencePenalty' cannot be > $presencePenaltyMaxValue";
    }
    if (temperature != null && temperature! < temperatureMinValue) {
      return "The value of 'temperature' cannot be < $temperatureMinValue";
    }
    if (temperature != null && temperature! > temperatureMaxValue) {
      return "The value of 'temperature' cannot be > $temperatureMaxValue";
    }
    if (topP != null && topP! < topPMinValue) {
      return "The value of 'topP' cannot be < $topPMinValue";
    }
    if (topP != null && topP! > topPMaxValue) {
      return "The value of 'topP' cannot be > $topPMaxValue";
    }
    return null;
  }

  /// Map representation of object (not serialized)
  Map<String, dynamic> toMap() {
    return {
      'model': model,
      'prompt': prompt,
      'best_of': bestOf,
      'echo': echo,
      'frequency_penalty': frequencyPenalty,
      'logit_bias': logitBias,
      'logprobs': logprobs,
      'max_tokens': maxTokens,
      'n': n,
      'presence_penalty': presencePenalty,
      'stop': stop,
      'stream': stream,
      'suffix': suffix,
      'temperature': temperature,
      'top_p': topP,
      'user': user,
    };
  }
}

// ==========================================
// ENUM: CreateCompletionRequestModelEnum
// ==========================================

/// No Description
enum CreateCompletionRequestModelEnum {
  @JsonValue('babbage-002')
  babbage002,
  @JsonValue('davinci-002')
  davinci002,
  @JsonValue('gpt-3.5-turbo-instruct')
  gpt35TurboInstruct,
  @JsonValue('text-davinci-003')
  textDavinci003,
  @JsonValue('text-davinci-002')
  textDavinci002,
  @JsonValue('text-davinci-001')
  textDavinci001,
  @JsonValue('code-davinci-002')
  codeDavinci002,
  @JsonValue('text-curie-001')
  textCurie001,
  @JsonValue('text-babbage-001')
  textBabbage001,
  @JsonValue('text-ada-001')
  textAda001,
}

// ==========================================
// CLASS: UnionCreateCompletionRequestModel
// ==========================================

/// ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.
@freezed
sealed class UnionCreateCompletionRequestModel
    with _$UnionCreateCompletionRequestModel {
  const UnionCreateCompletionRequestModel._();

  const factory UnionCreateCompletionRequestModel.string(
    String value,
  ) = UnionCreateCompletionRequestModelString;

  const factory UnionCreateCompletionRequestModel.enumeration(
    CreateCompletionRequestModelEnum value,
  ) = UnionCreateCompletionRequestModelEnum;

  /// Object construction from a JSON representation
  factory UnionCreateCompletionRequestModel.fromJson(
          Map<String, dynamic> json) =>
      _$UnionCreateCompletionRequestModelFromJson(json);
}

/// Custom JSON converter for [UnionCreateCompletionRequestModel]
class _UnionCreateCompletionRequestModelConverter
    implements JsonConverter<UnionCreateCompletionRequestModel, Object?> {
  const _UnionCreateCompletionRequestModelConverter();

  @override
  UnionCreateCompletionRequestModel fromJson(Object? json) {
    throw UnimplementedError();
  }

  @override
  Object? toJson(UnionCreateCompletionRequestModel data) {
    return switch (data) {
      UnionCreateCompletionRequestModelString(value: final v) => v,
      UnionCreateCompletionRequestModelEnum(value: final v) =>
        _$CreateCompletionRequestModelEnumEnumMap[v]!,
    };
  }
}
// ==========================================
// CLASS: UnionCreateCompletionRequestPrompt
// ==========================================

/// The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
///
/// Note that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the model will generate as if from the beginning of a new document.
@freezed
sealed class UnionCreateCompletionRequestPrompt
    with _$UnionCreateCompletionRequestPrompt {
  const UnionCreateCompletionRequestPrompt._();

  const factory UnionCreateCompletionRequestPrompt.string(
    String value,
  ) = UnionCreateCompletionRequestPromptString;

  const factory UnionCreateCompletionRequestPrompt.arrayString(
    List<String> value,
  ) = UnionCreateCompletionRequestPromptArrayString;

  const factory UnionCreateCompletionRequestPrompt.arrayInteger(
    List<int> value,
  ) = UnionCreateCompletionRequestPromptArrayInteger;

  const factory UnionCreateCompletionRequestPrompt.array(
    List<List<int>> value,
  ) = UnionCreateCompletionRequestPromptArray;

  /// Object construction from a JSON representation
  factory UnionCreateCompletionRequestPrompt.fromJson(
          Map<String, dynamic> json) =>
      _$UnionCreateCompletionRequestPromptFromJson(json);
}

/// Custom JSON converter for [UnionCreateCompletionRequestPrompt]
class _UnionCreateCompletionRequestPromptConverter
    implements JsonConverter<UnionCreateCompletionRequestPrompt, Object?> {
  const _UnionCreateCompletionRequestPromptConverter();

  @override
  UnionCreateCompletionRequestPrompt fromJson(Object? json) {
    throw UnimplementedError();
  }

  @override
  Object? toJson(UnionCreateCompletionRequestPrompt data) {
    return switch (data) {
      UnionCreateCompletionRequestPromptString(value: final v) => v,
      UnionCreateCompletionRequestPromptArrayString(value: final v) => v,
      UnionCreateCompletionRequestPromptArrayInteger(value: final v) => v,
      UnionCreateCompletionRequestPromptArray(value: final v) => v,
    };
  }
}
// ==========================================
// CLASS: UnionCreateCompletionRequestStop
// ==========================================

/// Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
@freezed
sealed class UnionCreateCompletionRequestStop
    with _$UnionCreateCompletionRequestStop {
  const UnionCreateCompletionRequestStop._();

  const factory UnionCreateCompletionRequestStop.string(
    String? value,
  ) = UnionCreateCompletionRequestStopString;

  const factory UnionCreateCompletionRequestStop.arrayString(
    List<String> value,
  ) = UnionCreateCompletionRequestStopArrayString;

  /// Object construction from a JSON representation
  factory UnionCreateCompletionRequestStop.fromJson(
          Map<String, dynamic> json) =>
      _$UnionCreateCompletionRequestStopFromJson(json);
}

/// Custom JSON converter for [UnionCreateCompletionRequestStop]
class _UnionCreateCompletionRequestStopConverter
    implements JsonConverter<UnionCreateCompletionRequestStop, Object?> {
  const _UnionCreateCompletionRequestStopConverter();

  @override
  UnionCreateCompletionRequestStop fromJson(Object? json) {
    throw UnimplementedError();
  }

  @override
  Object? toJson(UnionCreateCompletionRequestStop data) {
    return switch (data) {
      UnionCreateCompletionRequestStopString(value: final v) => v,
      UnionCreateCompletionRequestStopArrayString(value: final v) => v,
    };
  }
}

```