### PR TITLE
Improve safeEnum logic

### DIFF
--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -961,7 +961,7 @@ class SchemaGenerator extends BaseGenerator {
     if (value.startsWith(RegExp(r'[0-9]'))) {
       value = 'v$value';
     }
-    return value.replaceAll('.', '').camelCase;
+    return value.replaceAll('.', '_').camelCase;
   }
 
   // ------------------------------------------


### PR DESCRIPTION
`chat.completion` was being converted to `chatcompletion`. Now it is properly converted to `chatCompletion`.

cc @walsha2 