### PR TITLE
Ignore unused import warning in generated files

### DIFF
--- a/lib/src/generators/base.dart
+++ b/lib/src/generators/base.dart
@@ -38,7 +38,7 @@ abstract class BaseGenerator {
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: invalid_annotation_target
+// ignore_for_file: invalid_annotation_target, unused_import
 """;
     return header;
   }


### PR DESCRIPTION
pub.dev was complaining that `import 'dart:typed_data';` was not used in `client.dart`. I guess that import is still required in some cases, so I've just ignored that warning.

cc @walsha2 