### PR TITLE
fix: makes schema subtypes public, adds oneOf field support

### DIFF
--- a/lib/src/open_api/index.dart
+++ b/lib/src/open_api/index.dart
@@ -51,13 +51,13 @@ bool _checkReferenceTypes(name, ref, self) {
   final sType = self.runtimeType.toString().replaceAll(r'_$_', '');
 
   if (ref.runtimeType != self.runtimeType) {
-    if (ref is _SchemaMap && self is _SchemaObject) {
+    if (ref is SchemaMap && self is SchemaObject) {
       // Map is defined with typedef
       return true;
-    } else if (ref is _SchemaArray && self is _SchemaMap) {
+    } else if (ref is SchemaArray && self is SchemaMap) {
       // Array is defined with typedef
       return true;
-    } else if (self is _SchemaObject) {
+    } else if (self is SchemaObject) {
       // Reference types can be different if the reference is a SchemaObject
       return false;
     } else {

--- a/lib/src/open_api/index.freezed.dart
+++ b/lib/src/open_api/index.freezed.dart
@@ -8858,22 +8858,22 @@ abstract class _Response extends Response {
 Schema _$SchemaFromJson(Map<String, dynamic> json) {
   switch (json['type']) {
     case 'boolean':
-      return _SchemaBoolean.fromJson(json);
+      return SchemaBoolean.fromJson(json);
     case 'string':
-      return _SchemaString.fromJson(json);
+      return SchemaString.fromJson(json);
     case 'integer':
-      return _SchemaInteger.fromJson(json);
+      return SchemaInteger.fromJson(json);
     case 'number':
-      return _SchemaNumber.fromJson(json);
+      return SchemaNumber.fromJson(json);
     case 'enumeration':
-      return _SchemaEnum.fromJson(json);
+      return SchemaEnum.fromJson(json);
     case 'array':
-      return _SchemaArray.fromJson(json);
+      return SchemaArray.fromJson(json);
     case 'map':
-      return _SchemaMap.fromJson(json);
+      return SchemaMap.fromJson(json);
 
     default:
-      return _SchemaObject.fromJson(json);
+      return SchemaObject.fromJson(json);
   }
 }
 
@@ -8899,38 +8899,38 @@ mixin _$Schema {
 
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -9011,6 +9011,7 @@ abstract class _$$SchemaObjectImplCopyWith<$Res>
       @JsonKey(name: 'default') dynamic defaultValue,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
       @_SchemaListConverter() List<Schema>? allOf,
+      @_SchemaListConverter() List<Schema>? oneOf,
       @_SchemaListConverter() List<Schema>? anyOf,
       List<String>? required,
       Discriminator? discriminator,
@@ -9042,6 +9043,7 @@ class __$$SchemaObjectImplCopyWithImpl<$Res>
     Object? defaultValue = freezed,
     Object? ref = freezed,
     Object? allOf = freezed,
+    Object? oneOf = freezed,
     Object? anyOf = freezed,
     Object? required = freezed,
     Object? discriminator = freezed,
@@ -9070,6 +9072,10 @@ class __$$SchemaObjectImplCopyWithImpl<$Res>
       allOf: freezed == allOf
           ? _value._allOf
           : allOf // ignore: cast_nullable_to_non_nullable
+              as List<Schema>?,
+      oneOf: freezed == oneOf
+          ? _value._oneOf
+          : oneOf // ignore: cast_nullable_to_non_nullable
               as List<Schema>?,
       anyOf: freezed == anyOf
           ? _value._anyOf
@@ -9147,13 +9153,14 @@ class __$$SchemaObjectImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaObjectImpl extends _SchemaObject {
+class _$SchemaObjectImpl extends SchemaObject {
   const _$SchemaObjectImpl(
       {this.title,
       this.description,
       @JsonKey(name: 'default') this.defaultValue,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() this.ref,
       @_SchemaListConverter() final List<Schema>? allOf,
+      @_SchemaListConverter() final List<Schema>? oneOf,
       @_SchemaListConverter() final List<Schema>? anyOf,
       final List<String>? required,
       this.discriminator,
@@ -9163,6 +9170,7 @@ class _$SchemaObjectImpl extends _SchemaObject {
       this.xml,
       final String? $type})
       : _allOf = allOf,
+        _oneOf = oneOf,
         _anyOf = anyOf,
         _required = required,
         _properties = properties,
@@ -9201,6 +9209,20 @@ class _$SchemaObjectImpl extends _SchemaObject {
     final value = _allOf;
     if (value == null) return null;
     if (_allOf is EqualUnmodifiableListView) return _allOf;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// The allOf definition
+  final List<Schema>? _oneOf;
+
+  /// The allOf definition
+  @override
+  @_SchemaListConverter()
+  List<Schema>? get oneOf {
+    final value = _oneOf;
+    if (value == null) return null;
+    if (_oneOf is EqualUnmodifiableListView) return _oneOf;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
@@ -9270,7 +9292,7 @@ class _$SchemaObjectImpl extends _SchemaObject {
 
   @override
   String toString() {
-    return 'Schema.object(title: $title, description: $description, defaultValue: $defaultValue, ref: $ref, allOf: $allOf, anyOf: $anyOf, required: $required, discriminator: $discriminator, externalDocs: $externalDocs, properties: $properties, nullable: $nullable, xml: $xml)';
+    return 'Schema.object(title: $title, description: $description, defaultValue: $defaultValue, ref: $ref, allOf: $allOf, oneOf: $oneOf, anyOf: $anyOf, required: $required, discriminator: $discriminator, externalDocs: $externalDocs, properties: $properties, nullable: $nullable, xml: $xml)';
   }
 
   @override
@@ -9285,6 +9307,7 @@ class _$SchemaObjectImpl extends _SchemaObject {
                 .equals(other.defaultValue, defaultValue) &&
             (identical(other.ref, ref) || other.ref == ref) &&
             const DeepCollectionEquality().equals(other._allOf, _allOf) &&
+            const DeepCollectionEquality().equals(other._oneOf, _oneOf) &&
             const DeepCollectionEquality().equals(other._anyOf, _anyOf) &&
             const DeepCollectionEquality().equals(other._required, _required) &&
             (identical(other.discriminator, discriminator) ||
@@ -9307,6 +9330,7 @@ class _$SchemaObjectImpl extends _SchemaObject {
       const DeepCollectionEquality().hash(defaultValue),
       ref,
       const DeepCollectionEquality().hash(_allOf),
+      const DeepCollectionEquality().hash(_oneOf),
       const DeepCollectionEquality().hash(_anyOf),
       const DeepCollectionEquality().hash(_required),
       discriminator,
@@ -9326,14 +9350,14 @@ class _$SchemaObjectImpl extends _SchemaObject {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return object(this);
   }
@@ -9341,14 +9365,14 @@ class _$SchemaObjectImpl extends _SchemaObject {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return object?.call(this);
   }
@@ -9356,14 +9380,14 @@ class _$SchemaObjectImpl extends _SchemaObject {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (object != null) {
@@ -9380,13 +9404,14 @@ class _$SchemaObjectImpl extends _SchemaObject {
   }
 }
 
-abstract class _SchemaObject extends Schema {
-  const factory _SchemaObject(
+abstract class SchemaObject extends Schema {
+  const factory SchemaObject(
       {final String? title,
       final String? description,
       @JsonKey(name: 'default') final dynamic defaultValue,
       @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref,
       @_SchemaListConverter() final List<Schema>? allOf,
+      @_SchemaListConverter() final List<Schema>? oneOf,
       @_SchemaListConverter() final List<Schema>? anyOf,
       final List<String>? required,
       final Discriminator? discriminator,
@@ -9394,9 +9419,9 @@ abstract class _SchemaObject extends Schema {
       final Map<String, Schema>? properties,
       final bool? nullable,
       final Xml? xml}) = _$SchemaObjectImpl;
-  const _SchemaObject._() : super._();
+  const SchemaObject._() : super._();
 
-  factory _SchemaObject.fromJson(Map<String, dynamic> json) =
+  factory SchemaObject.fromJson(Map<String, dynamic> json) =
       _$SchemaObjectImpl.fromJson;
 
   /// A summary title of the schema
@@ -9421,6 +9446,10 @@ abstract class _SchemaObject extends Schema {
   /// The allOf definition
   @_SchemaListConverter()
   List<Schema>? get allOf;
+
+  /// The allOf definition
+  @_SchemaListConverter()
+  List<Schema>? get oneOf;
 
   /// The anyOf definition
   @_SchemaListConverter()
@@ -9547,7 +9576,7 @@ class __$$SchemaBooleanImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaBooleanImpl extends _SchemaBoolean {
+class _$SchemaBooleanImpl extends SchemaBoolean {
   const _$SchemaBooleanImpl(
       {this.xml,
       this.title,
@@ -9622,14 +9651,14 @@ class _$SchemaBooleanImpl extends _SchemaBoolean {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return boolean(this);
   }
@@ -9637,14 +9666,14 @@ class _$SchemaBooleanImpl extends _SchemaBoolean {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return boolean?.call(this);
   }
@@ -9652,14 +9681,14 @@ class _$SchemaBooleanImpl extends _SchemaBoolean {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (boolean != null) {
@@ -9676,8 +9705,8 @@ class _$SchemaBooleanImpl extends _SchemaBoolean {
   }
 }
 
-abstract class _SchemaBoolean extends Schema {
-  const factory _SchemaBoolean(
+abstract class SchemaBoolean extends Schema {
+  const factory SchemaBoolean(
           {final Xml? xml,
           final String? title,
           final String? description,
@@ -9686,9 +9715,9 @@ abstract class _SchemaBoolean extends Schema {
           final bool? example,
           @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref}) =
       _$SchemaBooleanImpl;
-  const _SchemaBoolean._() : super._();
+  const SchemaBoolean._() : super._();
 
-  factory _SchemaBoolean.fromJson(Map<String, dynamic> json) =
+  factory SchemaBoolean.fromJson(Map<String, dynamic> json) =
       _$SchemaBooleanImpl.fromJson;
 
   Xml? get xml;
@@ -9842,7 +9871,7 @@ class __$$SchemaStringImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaStringImpl extends _SchemaString {
+class _$SchemaStringImpl extends SchemaString {
   const _$SchemaStringImpl(
       {this.xml,
       this.title,
@@ -9961,14 +9990,14 @@ class _$SchemaStringImpl extends _SchemaString {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return string(this);
   }
@@ -9976,14 +10005,14 @@ class _$SchemaStringImpl extends _SchemaString {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return string?.call(this);
   }
@@ -9991,14 +10020,14 @@ class _$SchemaStringImpl extends _SchemaString {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (string != null) {
@@ -10015,8 +10044,8 @@ class _$SchemaStringImpl extends _SchemaString {
   }
 }
 
-abstract class _SchemaString extends Schema {
-  const factory _SchemaString(
+abstract class SchemaString extends Schema {
+  const factory SchemaString(
           {final Xml? xml,
           final String? title,
           final String? description,
@@ -10032,9 +10061,9 @@ abstract class _SchemaString extends Schema {
           final bool? exclusiveMaximum,
           @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref}) =
       _$SchemaStringImpl;
-  const _SchemaString._() : super._();
+  const SchemaString._() : super._();
 
-  factory _SchemaString.fromJson(Map<String, dynamic> json) =
+  factory SchemaString.fromJson(Map<String, dynamic> json) =
       _$SchemaStringImpl.fromJson;
 
   Xml? get xml;
@@ -10197,7 +10226,7 @@ class __$$SchemaIntegerImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaIntegerImpl extends _SchemaInteger {
+class _$SchemaIntegerImpl extends SchemaInteger {
   const _$SchemaIntegerImpl(
       {this.xml,
       this.title,
@@ -10317,14 +10346,14 @@ class _$SchemaIntegerImpl extends _SchemaInteger {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return integer(this);
   }
@@ -10332,14 +10361,14 @@ class _$SchemaIntegerImpl extends _SchemaInteger {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return integer?.call(this);
   }
@@ -10347,14 +10376,14 @@ class _$SchemaIntegerImpl extends _SchemaInteger {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (integer != null) {
@@ -10371,8 +10400,8 @@ class _$SchemaIntegerImpl extends _SchemaInteger {
   }
 }
 
-abstract class _SchemaInteger extends Schema {
-  const factory _SchemaInteger(
+abstract class SchemaInteger extends Schema {
+  const factory SchemaInteger(
       {final Xml? xml,
       final String? title,
       final String? description,
@@ -10389,9 +10418,9 @@ abstract class _SchemaInteger extends Schema {
       @JsonKey(name: '\$ref')
       @_SchemaRefConverter()
       final String? ref}) = _$SchemaIntegerImpl;
-  const _SchemaInteger._() : super._();
+  const SchemaInteger._() : super._();
 
-  factory _SchemaInteger.fromJson(Map<String, dynamic> json) =
+  factory SchemaInteger.fromJson(Map<String, dynamic> json) =
       _$SchemaIntegerImpl.fromJson;
 
   Xml? get xml;
@@ -10556,7 +10585,7 @@ class __$$SchemaNumberImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaNumberImpl extends _SchemaNumber {
+class _$SchemaNumberImpl extends SchemaNumber {
   const _$SchemaNumberImpl(
       {this.xml,
       this.title,
@@ -10676,14 +10705,14 @@ class _$SchemaNumberImpl extends _SchemaNumber {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return number(this);
   }
@@ -10691,14 +10720,14 @@ class _$SchemaNumberImpl extends _SchemaNumber {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return number?.call(this);
   }
@@ -10706,14 +10735,14 @@ class _$SchemaNumberImpl extends _SchemaNumber {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (number != null) {
@@ -10730,8 +10759,8 @@ class _$SchemaNumberImpl extends _SchemaNumber {
   }
 }
 
-abstract class _SchemaNumber extends Schema {
-  const factory _SchemaNumber(
+abstract class SchemaNumber extends Schema {
+  const factory SchemaNumber(
           {final Xml? xml,
           final String? title,
           final String? description,
@@ -10748,9 +10777,9 @@ abstract class _SchemaNumber extends Schema {
           @JsonKey(fromJson: _fromJsonDouble) final double? multipleOf,
           @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref}) =
       _$SchemaNumberImpl;
-  const _SchemaNumber._() : super._();
+  const SchemaNumber._() : super._();
 
-  factory _SchemaNumber.fromJson(Map<String, dynamic> json) =
+  factory SchemaNumber.fromJson(Map<String, dynamic> json) =
       _$SchemaNumberImpl.fromJson;
 
   Xml? get xml;
@@ -10869,7 +10898,7 @@ class __$$SchemaEnumImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaEnumImpl extends _SchemaEnum {
+class _$SchemaEnumImpl extends SchemaEnum {
   const _$SchemaEnumImpl(
       {this.title,
       this.description,
@@ -10968,14 +10997,14 @@ class _$SchemaEnumImpl extends _SchemaEnum {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return enumeration(this);
   }
@@ -10983,14 +11012,14 @@ class _$SchemaEnumImpl extends _SchemaEnum {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return enumeration?.call(this);
   }
@@ -10998,14 +11027,14 @@ class _$SchemaEnumImpl extends _SchemaEnum {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (enumeration != null) {
@@ -11022,8 +11051,8 @@ class _$SchemaEnumImpl extends _SchemaEnum {
   }
 }
 
-abstract class _SchemaEnum extends Schema {
-  const factory _SchemaEnum(
+abstract class SchemaEnum extends Schema {
+  const factory SchemaEnum(
           {final String? title,
           final String? description,
           final String? example,
@@ -11034,9 +11063,9 @@ abstract class _SchemaEnum extends Schema {
           @JsonKey(name: 'enum') final List<String>? values,
           @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref}) =
       _$SchemaEnumImpl;
-  const _SchemaEnum._() : super._();
+  const SchemaEnum._() : super._();
 
-  factory _SchemaEnum.fromJson(Map<String, dynamic> json) =
+  factory SchemaEnum.fromJson(Map<String, dynamic> json) =
       _$SchemaEnumImpl.fromJson;
 
   @override
@@ -11185,7 +11214,7 @@ class __$$SchemaArrayImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaArrayImpl extends _SchemaArray {
+class _$SchemaArrayImpl extends SchemaArray {
   const _$SchemaArrayImpl(
       {this.xml,
       this.title,
@@ -11295,14 +11324,14 @@ class _$SchemaArrayImpl extends _SchemaArray {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return array(this);
   }
@@ -11310,14 +11339,14 @@ class _$SchemaArrayImpl extends _SchemaArray {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return array?.call(this);
   }
@@ -11325,14 +11354,14 @@ class _$SchemaArrayImpl extends _SchemaArray {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (array != null) {
@@ -11349,8 +11378,8 @@ class _$SchemaArrayImpl extends _SchemaArray {
   }
 }
 
-abstract class _SchemaArray extends Schema {
-  const factory _SchemaArray(
+abstract class SchemaArray extends Schema {
+  const factory SchemaArray(
           {final Xml? xml,
           final String? title,
           final String? description,
@@ -11362,9 +11391,9 @@ abstract class _SchemaArray extends Schema {
           required final Schema items,
           @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref}) =
       _$SchemaArrayImpl;
-  const _SchemaArray._() : super._();
+  const SchemaArray._() : super._();
 
-  factory _SchemaArray.fromJson(Map<String, dynamic> json) =
+  factory SchemaArray.fromJson(Map<String, dynamic> json) =
       _$SchemaArrayImpl.fromJson;
 
   Xml? get xml;
@@ -11510,7 +11539,7 @@ class __$$SchemaMapImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$SchemaMapImpl extends _SchemaMap {
+class _$SchemaMapImpl extends SchemaMap {
   const _$SchemaMapImpl(
       {this.xml,
       this.title,
@@ -11624,14 +11653,14 @@ class _$SchemaMapImpl extends _SchemaMap {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_SchemaObject value) object,
-    required TResult Function(_SchemaBoolean value) boolean,
-    required TResult Function(_SchemaString value) string,
-    required TResult Function(_SchemaInteger value) integer,
-    required TResult Function(_SchemaNumber value) number,
-    required TResult Function(_SchemaEnum value) enumeration,
-    required TResult Function(_SchemaArray value) array,
-    required TResult Function(_SchemaMap value) map,
+    required TResult Function(SchemaObject value) object,
+    required TResult Function(SchemaBoolean value) boolean,
+    required TResult Function(SchemaString value) string,
+    required TResult Function(SchemaInteger value) integer,
+    required TResult Function(SchemaNumber value) number,
+    required TResult Function(SchemaEnum value) enumeration,
+    required TResult Function(SchemaArray value) array,
+    required TResult Function(SchemaMap value) map,
   }) {
     return map(this);
   }
@@ -11639,14 +11668,14 @@ class _$SchemaMapImpl extends _SchemaMap {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_SchemaObject value)? object,
-    TResult? Function(_SchemaBoolean value)? boolean,
-    TResult? Function(_SchemaString value)? string,
-    TResult? Function(_SchemaInteger value)? integer,
-    TResult? Function(_SchemaNumber value)? number,
-    TResult? Function(_SchemaEnum value)? enumeration,
-    TResult? Function(_SchemaArray value)? array,
-    TResult? Function(_SchemaMap value)? map,
+    TResult? Function(SchemaObject value)? object,
+    TResult? Function(SchemaBoolean value)? boolean,
+    TResult? Function(SchemaString value)? string,
+    TResult? Function(SchemaInteger value)? integer,
+    TResult? Function(SchemaNumber value)? number,
+    TResult? Function(SchemaEnum value)? enumeration,
+    TResult? Function(SchemaArray value)? array,
+    TResult? Function(SchemaMap value)? map,
   }) {
     return map?.call(this);
   }
@@ -11654,14 +11683,14 @@ class _$SchemaMapImpl extends _SchemaMap {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_SchemaObject value)? object,
-    TResult Function(_SchemaBoolean value)? boolean,
-    TResult Function(_SchemaString value)? string,
-    TResult Function(_SchemaInteger value)? integer,
-    TResult Function(_SchemaNumber value)? number,
-    TResult Function(_SchemaEnum value)? enumeration,
-    TResult Function(_SchemaArray value)? array,
-    TResult Function(_SchemaMap value)? map,
+    TResult Function(SchemaObject value)? object,
+    TResult Function(SchemaBoolean value)? boolean,
+    TResult Function(SchemaString value)? string,
+    TResult Function(SchemaInteger value)? integer,
+    TResult Function(SchemaNumber value)? number,
+    TResult Function(SchemaEnum value)? enumeration,
+    TResult Function(SchemaArray value)? array,
+    TResult Function(SchemaMap value)? map,
     required TResult orElse(),
   }) {
     if (map != null) {
@@ -11678,8 +11707,8 @@ class _$SchemaMapImpl extends _SchemaMap {
   }
 }
 
-abstract class _SchemaMap extends Schema {
-  const factory _SchemaMap(
+abstract class SchemaMap extends Schema {
+  const factory SchemaMap(
           {final Xml? xml,
           final String? title,
           final String? description,
@@ -11693,9 +11722,9 @@ abstract class _SchemaMap extends Schema {
           final Schema? valueSchema,
           @JsonKey(name: '\$ref') @_SchemaRefConverter() final String? ref}) =
       _$SchemaMapImpl;
-  const _SchemaMap._() : super._();
+  const SchemaMap._() : super._();
 
-  factory _SchemaMap.fromJson(Map<String, dynamic> json) =
+  factory SchemaMap.fromJson(Map<String, dynamic> json) =
       _$SchemaMapImpl.fromJson;
 
   Xml? get xml;

--- a/lib/src/open_api/index.freezed.dart
+++ b/lib/src/open_api/index.freezed.dart
@@ -6217,13 +6217,13 @@ abstract class _OpenId implements OpenId {
 Parameter _$ParameterFromJson(Map<String, dynamic> json) {
   switch (json['in']) {
     case 'cookie':
-      return _ParameterCookie.fromJson(json);
+      return ParameterCookie.fromJson(json);
     case 'header':
-      return _ParameterHeader.fromJson(json);
+      return ParameterHeader.fromJson(json);
     case 'query':
-      return _ParameterQuery.fromJson(json);
+      return ParameterQuery.fromJson(json);
     case 'path':
-      return _ParameterPath.fromJson(json);
+      return ParameterPath.fromJson(json);
 
     default:
       throw CheckedFromJsonException(
@@ -6247,26 +6247,26 @@ mixin _$Parameter {
 
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_ParameterCookie value) cookie,
-    required TResult Function(_ParameterHeader value) header,
-    required TResult Function(_ParameterQuery value) query,
-    required TResult Function(_ParameterPath value) path,
+    required TResult Function(ParameterCookie value) cookie,
+    required TResult Function(ParameterHeader value) header,
+    required TResult Function(ParameterQuery value) query,
+    required TResult Function(ParameterPath value) path,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_ParameterCookie value)? cookie,
-    TResult? Function(_ParameterHeader value)? header,
-    TResult? Function(_ParameterQuery value)? query,
-    TResult? Function(_ParameterPath value)? path,
+    TResult? Function(ParameterCookie value)? cookie,
+    TResult? Function(ParameterHeader value)? header,
+    TResult? Function(ParameterQuery value)? query,
+    TResult? Function(ParameterPath value)? path,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_ParameterCookie value)? cookie,
-    TResult Function(_ParameterHeader value)? header,
-    TResult Function(_ParameterQuery value)? query,
-    TResult Function(_ParameterPath value)? path,
+    TResult Function(ParameterCookie value)? cookie,
+    TResult Function(ParameterHeader value)? header,
+    TResult Function(ParameterQuery value)? query,
+    TResult Function(ParameterPath value)? path,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -6485,7 +6485,7 @@ class __$$ParameterCookieImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ParameterCookieImpl extends _ParameterCookie {
+class _$ParameterCookieImpl extends ParameterCookie {
   const _$ParameterCookieImpl(
       {this.name,
       this.description,
@@ -6577,10 +6577,10 @@ class _$ParameterCookieImpl extends _ParameterCookie {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_ParameterCookie value) cookie,
-    required TResult Function(_ParameterHeader value) header,
-    required TResult Function(_ParameterQuery value) query,
-    required TResult Function(_ParameterPath value) path,
+    required TResult Function(ParameterCookie value) cookie,
+    required TResult Function(ParameterHeader value) header,
+    required TResult Function(ParameterQuery value) query,
+    required TResult Function(ParameterPath value) path,
   }) {
     return cookie(this);
   }
@@ -6588,10 +6588,10 @@ class _$ParameterCookieImpl extends _ParameterCookie {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_ParameterCookie value)? cookie,
-    TResult? Function(_ParameterHeader value)? header,
-    TResult? Function(_ParameterQuery value)? query,
-    TResult? Function(_ParameterPath value)? path,
+    TResult? Function(ParameterCookie value)? cookie,
+    TResult? Function(ParameterHeader value)? header,
+    TResult? Function(ParameterQuery value)? query,
+    TResult? Function(ParameterPath value)? path,
   }) {
     return cookie?.call(this);
   }
@@ -6599,10 +6599,10 @@ class _$ParameterCookieImpl extends _ParameterCookie {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_ParameterCookie value)? cookie,
-    TResult Function(_ParameterHeader value)? header,
-    TResult Function(_ParameterQuery value)? query,
-    TResult Function(_ParameterPath value)? path,
+    TResult Function(ParameterCookie value)? cookie,
+    TResult Function(ParameterHeader value)? header,
+    TResult Function(ParameterQuery value)? query,
+    TResult Function(ParameterPath value)? path,
     required TResult orElse(),
   }) {
     if (cookie != null) {
@@ -6619,8 +6619,8 @@ class _$ParameterCookieImpl extends _ParameterCookie {
   }
 }
 
-abstract class _ParameterCookie extends Parameter {
-  const factory _ParameterCookie(
+abstract class ParameterCookie extends Parameter {
+  const factory ParameterCookie(
           {final String? name,
           final String? description,
           final bool? required,
@@ -6632,9 +6632,9 @@ abstract class _ParameterCookie extends Parameter {
           required final Schema schema,
           @JsonKey(name: '\$ref') @_ParamRefConverter() final String? ref}) =
       _$ParameterCookieImpl;
-  const _ParameterCookie._() : super._();
+  const ParameterCookie._() : super._();
 
-  factory _ParameterCookie.fromJson(Map<String, dynamic> json) =
+  factory ParameterCookie.fromJson(Map<String, dynamic> json) =
       _$ParameterCookieImpl.fromJson;
 
   @override
@@ -6772,7 +6772,7 @@ class __$$ParameterHeaderImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ParameterHeaderImpl extends _ParameterHeader {
+class _$ParameterHeaderImpl extends ParameterHeader {
   const _$ParameterHeaderImpl(
       {this.name,
       this.description,
@@ -6864,10 +6864,10 @@ class _$ParameterHeaderImpl extends _ParameterHeader {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_ParameterCookie value) cookie,
-    required TResult Function(_ParameterHeader value) header,
-    required TResult Function(_ParameterQuery value) query,
-    required TResult Function(_ParameterPath value) path,
+    required TResult Function(ParameterCookie value) cookie,
+    required TResult Function(ParameterHeader value) header,
+    required TResult Function(ParameterQuery value) query,
+    required TResult Function(ParameterPath value) path,
   }) {
     return header(this);
   }
@@ -6875,10 +6875,10 @@ class _$ParameterHeaderImpl extends _ParameterHeader {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_ParameterCookie value)? cookie,
-    TResult? Function(_ParameterHeader value)? header,
-    TResult? Function(_ParameterQuery value)? query,
-    TResult? Function(_ParameterPath value)? path,
+    TResult? Function(ParameterCookie value)? cookie,
+    TResult? Function(ParameterHeader value)? header,
+    TResult? Function(ParameterQuery value)? query,
+    TResult? Function(ParameterPath value)? path,
   }) {
     return header?.call(this);
   }
@@ -6886,10 +6886,10 @@ class _$ParameterHeaderImpl extends _ParameterHeader {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_ParameterCookie value)? cookie,
-    TResult Function(_ParameterHeader value)? header,
-    TResult Function(_ParameterQuery value)? query,
-    TResult Function(_ParameterPath value)? path,
+    TResult Function(ParameterCookie value)? cookie,
+    TResult Function(ParameterHeader value)? header,
+    TResult Function(ParameterQuery value)? query,
+    TResult Function(ParameterPath value)? path,
     required TResult orElse(),
   }) {
     if (header != null) {
@@ -6906,8 +6906,8 @@ class _$ParameterHeaderImpl extends _ParameterHeader {
   }
 }
 
-abstract class _ParameterHeader extends Parameter {
-  const factory _ParameterHeader(
+abstract class ParameterHeader extends Parameter {
+  const factory ParameterHeader(
           {final String? name,
           final String? description,
           final bool? required,
@@ -6919,9 +6919,9 @@ abstract class _ParameterHeader extends Parameter {
           required final Schema schema,
           @JsonKey(name: '\$ref') @_ParamRefConverter() final String? ref}) =
       _$ParameterHeaderImpl;
-  const _ParameterHeader._() : super._();
+  const ParameterHeader._() : super._();
 
-  factory _ParameterHeader.fromJson(Map<String, dynamic> json) =
+  factory ParameterHeader.fromJson(Map<String, dynamic> json) =
       _$ParameterHeaderImpl.fromJson;
 
   @override
@@ -7059,7 +7059,7 @@ class __$$ParameterQueryImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ParameterQueryImpl extends _ParameterQuery {
+class _$ParameterQueryImpl extends ParameterQuery {
   const _$ParameterQueryImpl(
       {this.name,
       this.description,
@@ -7151,10 +7151,10 @@ class _$ParameterQueryImpl extends _ParameterQuery {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_ParameterCookie value) cookie,
-    required TResult Function(_ParameterHeader value) header,
-    required TResult Function(_ParameterQuery value) query,
-    required TResult Function(_ParameterPath value) path,
+    required TResult Function(ParameterCookie value) cookie,
+    required TResult Function(ParameterHeader value) header,
+    required TResult Function(ParameterQuery value) query,
+    required TResult Function(ParameterPath value) path,
   }) {
     return query(this);
   }
@@ -7162,10 +7162,10 @@ class _$ParameterQueryImpl extends _ParameterQuery {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_ParameterCookie value)? cookie,
-    TResult? Function(_ParameterHeader value)? header,
-    TResult? Function(_ParameterQuery value)? query,
-    TResult? Function(_ParameterPath value)? path,
+    TResult? Function(ParameterCookie value)? cookie,
+    TResult? Function(ParameterHeader value)? header,
+    TResult? Function(ParameterQuery value)? query,
+    TResult? Function(ParameterPath value)? path,
   }) {
     return query?.call(this);
   }
@@ -7173,10 +7173,10 @@ class _$ParameterQueryImpl extends _ParameterQuery {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_ParameterCookie value)? cookie,
-    TResult Function(_ParameterHeader value)? header,
-    TResult Function(_ParameterQuery value)? query,
-    TResult Function(_ParameterPath value)? path,
+    TResult Function(ParameterCookie value)? cookie,
+    TResult Function(ParameterHeader value)? header,
+    TResult Function(ParameterQuery value)? query,
+    TResult Function(ParameterPath value)? path,
     required TResult orElse(),
   }) {
     if (query != null) {
@@ -7193,8 +7193,8 @@ class _$ParameterQueryImpl extends _ParameterQuery {
   }
 }
 
-abstract class _ParameterQuery extends Parameter {
-  const factory _ParameterQuery(
+abstract class ParameterQuery extends Parameter {
+  const factory ParameterQuery(
           {final String? name,
           final String? description,
           final bool? required,
@@ -7206,9 +7206,9 @@ abstract class _ParameterQuery extends Parameter {
           required final Schema schema,
           @JsonKey(name: '\$ref') @_ParamRefConverter() final String? ref}) =
       _$ParameterQueryImpl;
-  const _ParameterQuery._() : super._();
+  const ParameterQuery._() : super._();
 
-  factory _ParameterQuery.fromJson(Map<String, dynamic> json) =
+  factory ParameterQuery.fromJson(Map<String, dynamic> json) =
       _$ParameterQueryImpl.fromJson;
 
   @override
@@ -7330,7 +7330,7 @@ class __$$ParameterPathImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ParameterPathImpl extends _ParameterPath {
+class _$ParameterPathImpl extends ParameterPath {
   const _$ParameterPathImpl(
       {this.name,
       this.description,
@@ -7416,10 +7416,10 @@ class _$ParameterPathImpl extends _ParameterPath {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(_ParameterCookie value) cookie,
-    required TResult Function(_ParameterHeader value) header,
-    required TResult Function(_ParameterQuery value) query,
-    required TResult Function(_ParameterPath value) path,
+    required TResult Function(ParameterCookie value) cookie,
+    required TResult Function(ParameterHeader value) header,
+    required TResult Function(ParameterQuery value) query,
+    required TResult Function(ParameterPath value) path,
   }) {
     return path(this);
   }
@@ -7427,10 +7427,10 @@ class _$ParameterPathImpl extends _ParameterPath {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_ParameterCookie value)? cookie,
-    TResult? Function(_ParameterHeader value)? header,
-    TResult? Function(_ParameterQuery value)? query,
-    TResult? Function(_ParameterPath value)? path,
+    TResult? Function(ParameterCookie value)? cookie,
+    TResult? Function(ParameterHeader value)? header,
+    TResult? Function(ParameterQuery value)? query,
+    TResult? Function(ParameterPath value)? path,
   }) {
     return path?.call(this);
   }
@@ -7438,10 +7438,10 @@ class _$ParameterPathImpl extends _ParameterPath {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(_ParameterCookie value)? cookie,
-    TResult Function(_ParameterHeader value)? header,
-    TResult Function(_ParameterQuery value)? query,
-    TResult Function(_ParameterPath value)? path,
+    TResult Function(ParameterCookie value)? cookie,
+    TResult Function(ParameterHeader value)? header,
+    TResult Function(ParameterQuery value)? query,
+    TResult Function(ParameterPath value)? path,
     required TResult orElse(),
   }) {
     if (path != null) {
@@ -7458,8 +7458,8 @@ class _$ParameterPathImpl extends _ParameterPath {
   }
 }
 
-abstract class _ParameterPath extends Parameter {
-  const factory _ParameterPath(
+abstract class ParameterPath extends Parameter {
+  const factory ParameterPath(
           {final String? name,
           final String? description,
           final bool? deprecated,
@@ -7470,9 +7470,9 @@ abstract class _ParameterPath extends Parameter {
           final Schema? schema,
           @JsonKey(name: '\$ref') @_ParamRefConverter() final String? ref}) =
       _$ParameterPathImpl;
-  const _ParameterPath._() : super._();
+  const ParameterPath._() : super._();
 
-  factory _ParameterPath.fromJson(Map<String, dynamic> json) =
+  factory ParameterPath.fromJson(Map<String, dynamic> json) =
       _$ParameterPathImpl.fromJson;
 
   @override

--- a/lib/src/open_api/index.g.dart
+++ b/lib/src/open_api/index.g.dart
@@ -24,21 +24,15 @@ _$OAuthFlowsImpl _$$OAuthFlowsImplFromJson(Map<String, dynamic> json) =>
               json['authorizationCode'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$OAuthFlowsImplToJson(_$OAuthFlowsImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('implicit', instance.implicit?.toJson());
-  writeNotNull('password', instance.password?.toJson());
-  writeNotNull('clientCredentials', instance.clientCredentials?.toJson());
-  writeNotNull('authorizationCode', instance.authorizationCode?.toJson());
-  return val;
-}
+Map<String, dynamic> _$$OAuthFlowsImplToJson(_$OAuthFlowsImpl instance) =>
+    <String, dynamic>{
+      if (instance.implicit?.toJson() case final value?) 'implicit': value,
+      if (instance.password?.toJson() case final value?) 'password': value,
+      if (instance.clientCredentials?.toJson() case final value?)
+        'clientCredentials': value,
+      if (instance.authorizationCode?.toJson() case final value?)
+        'authorizationCode': value,
+    };
 
 _$OAuthFlowImplicitImpl _$$OAuthFlowImplicitImplFromJson(
         Map<String, dynamic> json) =>
@@ -50,22 +44,13 @@ _$OAuthFlowImplicitImpl _$$OAuthFlowImplicitImplFromJson(
     );
 
 Map<String, dynamic> _$$OAuthFlowImplicitImplToJson(
-    _$OAuthFlowImplicitImpl instance) {
-  final val = <String, dynamic>{
-    'authorizationUrl': instance.authorizationUrl,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('refreshUrl', instance.refreshUrl);
-  val['scopes'] = instance.scopes;
-  val['unionType'] = instance.$type;
-  return val;
-}
+        _$OAuthFlowImplicitImpl instance) =>
+    <String, dynamic>{
+      'authorizationUrl': instance.authorizationUrl,
+      if (instance.refreshUrl case final value?) 'refreshUrl': value,
+      'scopes': instance.scopes,
+      'unionType': instance.$type,
+    };
 
 _$OAuthFlowPasswordImpl _$$OAuthFlowPasswordImplFromJson(
         Map<String, dynamic> json) =>
@@ -77,22 +62,13 @@ _$OAuthFlowPasswordImpl _$$OAuthFlowPasswordImplFromJson(
     );
 
 Map<String, dynamic> _$$OAuthFlowPasswordImplToJson(
-    _$OAuthFlowPasswordImpl instance) {
-  final val = <String, dynamic>{
-    'tokenUrl': instance.tokenUrl,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('refreshUrl', instance.refreshUrl);
-  val['scopes'] = instance.scopes;
-  val['unionType'] = instance.$type;
-  return val;
-}
+        _$OAuthFlowPasswordImpl instance) =>
+    <String, dynamic>{
+      'tokenUrl': instance.tokenUrl,
+      if (instance.refreshUrl case final value?) 'refreshUrl': value,
+      'scopes': instance.scopes,
+      'unionType': instance.$type,
+    };
 
 _$OAuthFlowClientCredentialsImpl _$$OAuthFlowClientCredentialsImplFromJson(
         Map<String, dynamic> json) =>
@@ -104,22 +80,13 @@ _$OAuthFlowClientCredentialsImpl _$$OAuthFlowClientCredentialsImplFromJson(
     );
 
 Map<String, dynamic> _$$OAuthFlowClientCredentialsImplToJson(
-    _$OAuthFlowClientCredentialsImpl instance) {
-  final val = <String, dynamic>{
-    'tokenUrl': instance.tokenUrl,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('refreshUrl', instance.refreshUrl);
-  val['scopes'] = instance.scopes;
-  val['unionType'] = instance.$type;
-  return val;
-}
+        _$OAuthFlowClientCredentialsImpl instance) =>
+    <String, dynamic>{
+      'tokenUrl': instance.tokenUrl,
+      if (instance.refreshUrl case final value?) 'refreshUrl': value,
+      'scopes': instance.scopes,
+      'unionType': instance.$type,
+    };
 
 _$OAuthFlowAuthorizationCodeImpl _$$OAuthFlowAuthorizationCodeImplFromJson(
         Map<String, dynamic> json) =>
@@ -132,23 +99,14 @@ _$OAuthFlowAuthorizationCodeImpl _$$OAuthFlowAuthorizationCodeImplFromJson(
     );
 
 Map<String, dynamic> _$$OAuthFlowAuthorizationCodeImplToJson(
-    _$OAuthFlowAuthorizationCodeImpl instance) {
-  final val = <String, dynamic>{
-    'authorizationUrl': instance.authorizationUrl,
-    'tokenUrl': instance.tokenUrl,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('refreshUrl', instance.refreshUrl);
-  val['scopes'] = instance.scopes;
-  val['unionType'] = instance.$type;
-  return val;
-}
+        _$OAuthFlowAuthorizationCodeImpl instance) =>
+    <String, dynamic>{
+      'authorizationUrl': instance.authorizationUrl,
+      'tokenUrl': instance.tokenUrl,
+      if (instance.refreshUrl case final value?) 'refreshUrl': value,
+      'scopes': instance.scopes,
+      'unionType': instance.$type,
+    };
 
 _$ComponentsImpl _$$ComponentsImplFromJson(Map<String, dynamic> json) =>
     _$ComponentsImpl(
@@ -185,40 +143,41 @@ _$ComponentsImpl _$$ComponentsImplFromJson(Map<String, dynamic> json) =>
       ),
     );
 
-Map<String, dynamic> _$$ComponentsImplToJson(_$ComponentsImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull(
-      'schemas',
-      _$JsonConverterToJson<Map<String, dynamic>, Map<String, Schema>>(
-          instance.schemas, const _SchemaMapConverter().toJson));
-  writeNotNull(
-      'responses', instance.responses?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull('parameters',
-      instance.parameters?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(
-      'examples', instance.examples?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull('requestBodies',
-      instance.requestBodies?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(
-      'headers', instance.headers?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull('securitySchemes',
-      instance.securitySchemes?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull('links', instance.links?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(
-      'callbacks',
-      _$JsonConverterToJson<Map<String, dynamic>, Map<String, ApiCallback>>(
-          instance.callbacks, const _ApiCallbackMapConverter().toJson));
-  writeNotNull(
-      'pathItems', instance.pathItems?.map((k, e) => MapEntry(k, e.toJson())));
-  return val;
-}
+Map<String, dynamic> _$$ComponentsImplToJson(_$ComponentsImpl instance) =>
+    <String, dynamic>{
+      if (_$JsonConverterToJson<Map<String, dynamic>, Map<String, Schema>>(
+              instance.schemas, const _SchemaMapConverter().toJson)
+          case final value?)
+        'schemas': value,
+      if (instance.responses?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'responses': value,
+      if (instance.parameters?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'parameters': value,
+      if (instance.examples?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'examples': value,
+      if (instance.requestBodies?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'requestBodies': value,
+      if (instance.headers?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'headers': value,
+      if (instance.securitySchemes?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'securitySchemes': value,
+      if (instance.links?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'links': value,
+      if (_$JsonConverterToJson<Map<String, dynamic>, Map<String, ApiCallback>>(
+              instance.callbacks, const _ApiCallbackMapConverter().toJson)
+          case final value?)
+        'callbacks': value,
+      if (instance.pathItems?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'pathItems': value,
+    };
 
 Value? _$JsonConverterFromJson<Json, Value>(
   Object? json,
@@ -239,20 +198,12 @@ _$ContactImpl _$$ContactImplFromJson(Map<String, dynamic> json) =>
       url: json['url'] as String?,
     );
 
-Map<String, dynamic> _$$ContactImplToJson(_$ContactImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('email', instance.email);
-  writeNotNull('url', instance.url);
-  return val;
-}
+Map<String, dynamic> _$$ContactImplToJson(_$ContactImpl instance) =>
+    <String, dynamic>{
+      if (instance.name case final value?) 'name': value,
+      if (instance.email case final value?) 'email': value,
+      if (instance.url case final value?) 'url': value,
+    };
 
 _$DiscriminatorImpl _$$DiscriminatorImplFromJson(Map<String, dynamic> json) =>
     _$DiscriminatorImpl(
@@ -262,38 +213,21 @@ _$DiscriminatorImpl _$$DiscriminatorImplFromJson(Map<String, dynamic> json) =>
       ),
     );
 
-Map<String, dynamic> _$$DiscriminatorImplToJson(_$DiscriminatorImpl instance) {
-  final val = <String, dynamic>{
-    'propertyName': instance.propertyName,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('mapping', instance.mapping);
-  return val;
-}
+Map<String, dynamic> _$$DiscriminatorImplToJson(_$DiscriminatorImpl instance) =>
+    <String, dynamic>{
+      'propertyName': instance.propertyName,
+      if (instance.mapping case final value?) 'mapping': value,
+    };
 
 _$EncodingImpl _$$EncodingImplFromJson(Map<String, dynamic> json) =>
     _$EncodingImpl(
       contentType: json['contentType'] as String?,
     );
 
-Map<String, dynamic> _$$EncodingImplToJson(_$EncodingImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('contentType', instance.contentType);
-  return val;
-}
+Map<String, dynamic> _$$EncodingImplToJson(_$EncodingImpl instance) =>
+    <String, dynamic>{
+      if (instance.contentType case final value?) 'contentType': value,
+    };
 
 _$ExampleObjectImpl _$$ExampleObjectImplFromJson(Map<String, dynamic> json) =>
     _$ExampleObjectImpl(
@@ -304,22 +238,15 @@ _$ExampleObjectImpl _$$ExampleObjectImplFromJson(Map<String, dynamic> json) =>
       ref: const _ExampleRefConverter().fromJson(json[r'$ref'] as String?),
     );
 
-Map<String, dynamic> _$$ExampleObjectImplToJson(_$ExampleObjectImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('summary', instance.summary);
-  writeNotNull('description', instance.description);
-  writeNotNull('value', instance.value);
-  writeNotNull('externalValue', instance.externalValue);
-  writeNotNull(r'$ref', const _ExampleRefConverter().toJson(instance.ref));
-  return val;
-}
+Map<String, dynamic> _$$ExampleObjectImplToJson(_$ExampleObjectImpl instance) =>
+    <String, dynamic>{
+      if (instance.summary case final value?) 'summary': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.value case final value?) 'value': value,
+      if (instance.externalValue case final value?) 'externalValue': value,
+      if (const _ExampleRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+    };
 
 _$ExternalDocsImpl _$$ExternalDocsImplFromJson(Map<String, dynamic> json) =>
     _$ExternalDocsImpl(
@@ -327,19 +254,11 @@ _$ExternalDocsImpl _$$ExternalDocsImplFromJson(Map<String, dynamic> json) =>
       url: json['url'] as String,
     );
 
-Map<String, dynamic> _$$ExternalDocsImplToJson(_$ExternalDocsImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  val['url'] = instance.url;
-  return val;
-}
+Map<String, dynamic> _$$ExternalDocsImplToJson(_$ExternalDocsImpl instance) =>
+    <String, dynamic>{
+      if (instance.description case final value?) 'description': value,
+      'url': instance.url,
+    };
 
 _$HeaderImpl _$$HeaderImplFromJson(Map<String, dynamic> json) => _$HeaderImpl(
       description: json['description'] as String?,
@@ -348,19 +267,11 @@ _$HeaderImpl _$$HeaderImplFromJson(Map<String, dynamic> json) => _$HeaderImpl(
           : Schema.fromJson(json['schema'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$HeaderImplToJson(_$HeaderImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  writeNotNull('schema', instance.schema?.toJson());
-  return val;
-}
+Map<String, dynamic> _$$HeaderImplToJson(_$HeaderImpl instance) =>
+    <String, dynamic>{
+      if (instance.description case final value?) 'description': value,
+      if (instance.schema?.toJson() case final value?) 'schema': value,
+    };
 
 _$InfoImpl _$$InfoImplFromJson(Map<String, dynamic> json) => _$InfoImpl(
       title: json['title'] as String,
@@ -376,25 +287,16 @@ _$InfoImpl _$$InfoImplFromJson(Map<String, dynamic> json) => _$InfoImpl(
       version: json['version'] as String,
     );
 
-Map<String, dynamic> _$$InfoImplToJson(_$InfoImpl instance) {
-  final val = <String, dynamic>{
-    'title': instance.title,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('summary', instance.summary);
-  writeNotNull('description', instance.description);
-  writeNotNull('termsOfService', instance.termsOfService);
-  writeNotNull('contact', instance.contact?.toJson());
-  writeNotNull('license', instance.license?.toJson());
-  val['version'] = instance.version;
-  return val;
-}
+Map<String, dynamic> _$$InfoImplToJson(_$InfoImpl instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      if (instance.summary case final value?) 'summary': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.termsOfService case final value?) 'termsOfService': value,
+      if (instance.contact?.toJson() case final value?) 'contact': value,
+      if (instance.license?.toJson() case final value?) 'license': value,
+      'version': instance.version,
+    };
 
 _$LicenseImpl _$$LicenseImplFromJson(Map<String, dynamic> json) =>
     _$LicenseImpl(
@@ -403,21 +305,12 @@ _$LicenseImpl _$$LicenseImplFromJson(Map<String, dynamic> json) =>
       url: json['url'] as String?,
     );
 
-Map<String, dynamic> _$$LicenseImplToJson(_$LicenseImpl instance) {
-  final val = <String, dynamic>{
-    'name': instance.name,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('identifier', instance.identifier);
-  writeNotNull('url', instance.url);
-  return val;
-}
+Map<String, dynamic> _$$LicenseImplToJson(_$LicenseImpl instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      if (instance.identifier case final value?) 'identifier': value,
+      if (instance.url case final value?) 'url': value,
+    };
 
 _$LinkImpl _$$LinkImplFromJson(Map<String, dynamic> json) => _$LinkImpl(
       ref: const _LinkRefConverter().fromJson(json[r'$ref'] as String?),
@@ -427,20 +320,13 @@ _$LinkImpl _$$LinkImplFromJson(Map<String, dynamic> json) => _$LinkImpl(
       ),
     );
 
-Map<String, dynamic> _$$LinkImplToJson(_$LinkImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull(r'$ref', const _LinkRefConverter().toJson(instance.ref));
-  writeNotNull('operationId', instance.operationId);
-  writeNotNull('parameters', instance.parameters);
-  return val;
-}
+Map<String, dynamic> _$$LinkImplToJson(_$LinkImpl instance) =>
+    <String, dynamic>{
+      if (const _LinkRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      if (instance.operationId case final value?) 'operationId': value,
+      if (instance.parameters case final value?) 'parameters': value,
+    };
 
 _$MediaTypeImpl _$$MediaTypeImplFromJson(Map<String, dynamic> json) =>
     _$MediaTypeImpl(
@@ -456,23 +342,17 @@ _$MediaTypeImpl _$$MediaTypeImplFromJson(Map<String, dynamic> json) =>
       ),
     );
 
-Map<String, dynamic> _$$MediaTypeImplToJson(_$MediaTypeImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('schema', instance.schema?.toJson());
-  writeNotNull('example', instance.example);
-  writeNotNull(
-      'examples', instance.examples?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(
-      'encoding', instance.encoding?.map((k, e) => MapEntry(k, e.toJson())));
-  return val;
-}
+Map<String, dynamic> _$$MediaTypeImplToJson(_$MediaTypeImpl instance) =>
+    <String, dynamic>{
+      if (instance.schema?.toJson() case final value?) 'schema': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.examples?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'examples': value,
+      if (instance.encoding?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'encoding': value,
+    };
 
 _$OperationImpl _$$OperationImplFromJson(Map<String, dynamic> json) =>
     _$OperationImpl(
@@ -504,34 +384,32 @@ _$OperationImpl _$$OperationImplFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$OperationImplToJson(_$OperationImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('tags', instance.tags);
-  writeNotNull('summary', instance.summary);
-  writeNotNull('description', instance.description);
-  writeNotNull('externalDocs', instance.externalDocs?.toJson());
-  writeNotNull('operationId', instance.id);
-  writeNotNull(
-      'parameters', instance.parameters?.map((e) => e.toJson()).toList());
-  writeNotNull('requestBody', instance.requestBody?.toJson());
-  writeNotNull(
-      'responses', instance.responses?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(
-      'callbacks',
-      _$JsonConverterToJson<Map<String, dynamic>, Map<String, ApiCallback>>(
-          instance.callbacks, const _ApiCallbackMapConverter().toJson));
-  writeNotNull('deprecated', instance.deprecated);
-  writeNotNull('security', instance.security?.map((e) => e.toJson()).toList());
-  writeNotNull('servers', instance.servers?.map((e) => e.toJson()).toList());
-  return val;
-}
+Map<String, dynamic> _$$OperationImplToJson(_$OperationImpl instance) =>
+    <String, dynamic>{
+      if (instance.tags case final value?) 'tags': value,
+      if (instance.summary case final value?) 'summary': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.externalDocs?.toJson() case final value?)
+        'externalDocs': value,
+      if (instance.id case final value?) 'operationId': value,
+      if (instance.parameters?.map((e) => e.toJson()).toList()
+          case final value?)
+        'parameters': value,
+      if (instance.requestBody?.toJson() case final value?)
+        'requestBody': value,
+      if (instance.responses?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'responses': value,
+      if (_$JsonConverterToJson<Map<String, dynamic>, Map<String, ApiCallback>>(
+              instance.callbacks, const _ApiCallbackMapConverter().toJson)
+          case final value?)
+        'callbacks': value,
+      if (instance.deprecated case final value?) 'deprecated': value,
+      if (instance.security?.map((e) => e.toJson()).toList() case final value?)
+        'security': value,
+      if (instance.servers?.map((e) => e.toJson()).toList() case final value?)
+        'servers': value,
+    };
 
 _$OpenIdImpl _$$OpenIdImplFromJson(Map<String, dynamic> json) => _$OpenIdImpl(
       issuer: json['issuer'] as String?,
@@ -583,44 +461,44 @@ _$OpenIdImpl _$$OpenIdImplFromJson(Map<String, dynamic> json) => _$OpenIdImpl(
               .toList(),
     );
 
-Map<String, dynamic> _$$OpenIdImplToJson(_$OpenIdImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('issuer', instance.issuer);
-  writeNotNull('authorization_endpoint', instance.authorizationEndpoint);
-  writeNotNull('token_endpoint', instance.tokenEndpoint);
-  writeNotNull(
-      'device_authorization_endpoint', instance.deviceAuthorizationEndpoint);
-  writeNotNull('userinfo_endpoint', instance.userinfoEndpoint);
-  writeNotNull('mfa_challenge_endpoint', instance.mfaChallengeEndpoint);
-  writeNotNull('jwks_uri', instance.jwksUri);
-  writeNotNull('registration_endpoint', instance.registrationEndpoint);
-  writeNotNull('revocation_endpoint', instance.revocationEndpoint);
-  writeNotNull('scopes_supported', instance.scopesSupported);
-  writeNotNull('response_types_supported', instance.responseTypesSupported);
-  writeNotNull('code_challenge_methods_supported',
-      instance.codeChallengeMethodsSupported);
-  writeNotNull('response_modes_supported', instance.responseModesSupported);
-  writeNotNull('subject_types_supported', instance.subjectTypesSupported);
-  writeNotNull('id_token_signing_alg_values_supported',
-      instance.idTokenSigningAlgValuesSupported);
-  writeNotNull('token_endpoint_auth_methods_supported',
-      instance.tokenEndpointAuthMethodsSupported);
-  writeNotNull('claims_supported', instance.claimsSupported);
-  writeNotNull(
-      'request_uri_parameter_supported', instance.requestUriParameterSupported);
-  writeNotNull(
-      'request_parameter_supported', instance.requestParameterSupported);
-  writeNotNull('token_endpoint_auth_signing_alg_values_supported',
-      instance.tokenEndpointAuthSigningAlgValuesSupported);
-  return val;
-}
+Map<String, dynamic> _$$OpenIdImplToJson(_$OpenIdImpl instance) =>
+    <String, dynamic>{
+      if (instance.issuer case final value?) 'issuer': value,
+      if (instance.authorizationEndpoint case final value?)
+        'authorization_endpoint': value,
+      if (instance.tokenEndpoint case final value?) 'token_endpoint': value,
+      if (instance.deviceAuthorizationEndpoint case final value?)
+        'device_authorization_endpoint': value,
+      if (instance.userinfoEndpoint case final value?)
+        'userinfo_endpoint': value,
+      if (instance.mfaChallengeEndpoint case final value?)
+        'mfa_challenge_endpoint': value,
+      if (instance.jwksUri case final value?) 'jwks_uri': value,
+      if (instance.registrationEndpoint case final value?)
+        'registration_endpoint': value,
+      if (instance.revocationEndpoint case final value?)
+        'revocation_endpoint': value,
+      if (instance.scopesSupported case final value?) 'scopes_supported': value,
+      if (instance.responseTypesSupported case final value?)
+        'response_types_supported': value,
+      if (instance.codeChallengeMethodsSupported case final value?)
+        'code_challenge_methods_supported': value,
+      if (instance.responseModesSupported case final value?)
+        'response_modes_supported': value,
+      if (instance.subjectTypesSupported case final value?)
+        'subject_types_supported': value,
+      if (instance.idTokenSigningAlgValuesSupported case final value?)
+        'id_token_signing_alg_values_supported': value,
+      if (instance.tokenEndpointAuthMethodsSupported case final value?)
+        'token_endpoint_auth_methods_supported': value,
+      if (instance.claimsSupported case final value?) 'claims_supported': value,
+      if (instance.requestUriParameterSupported case final value?)
+        'request_uri_parameter_supported': value,
+      if (instance.requestParameterSupported case final value?)
+        'request_parameter_supported': value,
+      if (instance.tokenEndpointAuthSigningAlgValuesSupported case final value?)
+        'token_endpoint_auth_signing_alg_values_supported': value,
+    };
 
 _$ParameterCookieImpl _$$ParameterCookieImplFromJson(
         Map<String, dynamic> json) =>
@@ -639,28 +517,21 @@ _$ParameterCookieImpl _$$ParameterCookieImplFromJson(
     );
 
 Map<String, dynamic> _$$ParameterCookieImplToJson(
-    _$ParameterCookieImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('description', instance.description);
-  writeNotNull('required', instance.required);
-  writeNotNull('deprecated', instance.deprecated);
-  writeNotNull('style', instance.style);
-  writeNotNull('explode', instance.explode);
-  writeNotNull('allowReserved', instance.allowReserved);
-  writeNotNull('example', instance.example);
-  val['schema'] = instance.schema.toJson();
-  writeNotNull(r'$ref', const _ParamRefConverter().toJson(instance.ref));
-  val['in'] = instance.$type;
-  return val;
-}
+        _$ParameterCookieImpl instance) =>
+    <String, dynamic>{
+      if (instance.name case final value?) 'name': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.required case final value?) 'required': value,
+      if (instance.deprecated case final value?) 'deprecated': value,
+      if (instance.style case final value?) 'style': value,
+      if (instance.explode case final value?) 'explode': value,
+      if (instance.allowReserved case final value?) 'allowReserved': value,
+      if (instance.example case final value?) 'example': value,
+      'schema': instance.schema.toJson(),
+      if (const _ParamRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'in': instance.$type,
+    };
 
 _$ParameterHeaderImpl _$$ParameterHeaderImplFromJson(
         Map<String, dynamic> json) =>
@@ -679,28 +550,21 @@ _$ParameterHeaderImpl _$$ParameterHeaderImplFromJson(
     );
 
 Map<String, dynamic> _$$ParameterHeaderImplToJson(
-    _$ParameterHeaderImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('description', instance.description);
-  writeNotNull('required', instance.required);
-  writeNotNull('deprecated', instance.deprecated);
-  writeNotNull('style', instance.style);
-  writeNotNull('explode', instance.explode);
-  writeNotNull('allowReserved', instance.allowReserved);
-  writeNotNull('example', instance.example);
-  val['schema'] = instance.schema.toJson();
-  writeNotNull(r'$ref', const _ParamRefConverter().toJson(instance.ref));
-  val['in'] = instance.$type;
-  return val;
-}
+        _$ParameterHeaderImpl instance) =>
+    <String, dynamic>{
+      if (instance.name case final value?) 'name': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.required case final value?) 'required': value,
+      if (instance.deprecated case final value?) 'deprecated': value,
+      if (instance.style case final value?) 'style': value,
+      if (instance.explode case final value?) 'explode': value,
+      if (instance.allowReserved case final value?) 'allowReserved': value,
+      if (instance.example case final value?) 'example': value,
+      'schema': instance.schema.toJson(),
+      if (const _ParamRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'in': instance.$type,
+    };
 
 _$ParameterQueryImpl _$$ParameterQueryImplFromJson(Map<String, dynamic> json) =>
     _$ParameterQueryImpl(
@@ -718,28 +582,21 @@ _$ParameterQueryImpl _$$ParameterQueryImplFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$$ParameterQueryImplToJson(
-    _$ParameterQueryImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('description', instance.description);
-  writeNotNull('required', instance.required);
-  writeNotNull('deprecated', instance.deprecated);
-  writeNotNull('style', instance.style);
-  writeNotNull('explode', instance.explode);
-  writeNotNull('allowReserved', instance.allowReserved);
-  writeNotNull('example', instance.example);
-  val['schema'] = instance.schema.toJson();
-  writeNotNull(r'$ref', const _ParamRefConverter().toJson(instance.ref));
-  val['in'] = instance.$type;
-  return val;
-}
+        _$ParameterQueryImpl instance) =>
+    <String, dynamic>{
+      if (instance.name case final value?) 'name': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.required case final value?) 'required': value,
+      if (instance.deprecated case final value?) 'deprecated': value,
+      if (instance.style case final value?) 'style': value,
+      if (instance.explode case final value?) 'explode': value,
+      if (instance.allowReserved case final value?) 'allowReserved': value,
+      if (instance.example case final value?) 'example': value,
+      'schema': instance.schema.toJson(),
+      if (const _ParamRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'in': instance.$type,
+    };
 
 _$ParameterPathImpl _$$ParameterPathImplFromJson(Map<String, dynamic> json) =>
     _$ParameterPathImpl(
@@ -757,27 +614,20 @@ _$ParameterPathImpl _$$ParameterPathImplFromJson(Map<String, dynamic> json) =>
       $type: json['in'] as String?,
     );
 
-Map<String, dynamic> _$$ParameterPathImplToJson(_$ParameterPathImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('description', instance.description);
-  writeNotNull('deprecated', instance.deprecated);
-  writeNotNull('style', instance.style);
-  writeNotNull('explode', instance.explode);
-  writeNotNull('allowReserved', instance.allowReserved);
-  writeNotNull('example', instance.example);
-  writeNotNull('schema', instance.schema?.toJson());
-  writeNotNull(r'$ref', const _ParamRefConverter().toJson(instance.ref));
-  val['in'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$ParameterPathImplToJson(_$ParameterPathImpl instance) =>
+    <String, dynamic>{
+      if (instance.name case final value?) 'name': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.deprecated case final value?) 'deprecated': value,
+      if (instance.style case final value?) 'style': value,
+      if (instance.explode case final value?) 'explode': value,
+      if (instance.allowReserved case final value?) 'allowReserved': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.schema?.toJson() case final value?) 'schema': value,
+      if (const _ParamRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'in': instance.$type,
+    };
 
 _$PathItemImpl _$$PathItemImplFromJson(Map<String, dynamic> json) =>
     _$PathItemImpl(
@@ -816,31 +666,26 @@ _$PathItemImpl _$$PathItemImplFromJson(Map<String, dynamic> json) =>
       ref: const _PathRefConverter().fromJson(json[r'$ref'] as String?),
     );
 
-Map<String, dynamic> _$$PathItemImplToJson(_$PathItemImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('summary', instance.summary);
-  writeNotNull('description', instance.description);
-  writeNotNull('get', instance.get?.toJson());
-  writeNotNull('put', instance.put?.toJson());
-  writeNotNull('post', instance.post?.toJson());
-  writeNotNull('delete', instance.delete?.toJson());
-  writeNotNull('options', instance.options?.toJson());
-  writeNotNull('head', instance.head?.toJson());
-  writeNotNull('patch', instance.patch?.toJson());
-  writeNotNull('trace', instance.trace?.toJson());
-  writeNotNull('servers', instance.servers?.map((e) => e.toJson()).toList());
-  writeNotNull(
-      'parameters', instance.parameters?.map((e) => e.toJson()).toList());
-  writeNotNull(r'$ref', const _PathRefConverter().toJson(instance.ref));
-  return val;
-}
+Map<String, dynamic> _$$PathItemImplToJson(_$PathItemImpl instance) =>
+    <String, dynamic>{
+      if (instance.summary case final value?) 'summary': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.get?.toJson() case final value?) 'get': value,
+      if (instance.put?.toJson() case final value?) 'put': value,
+      if (instance.post?.toJson() case final value?) 'post': value,
+      if (instance.delete?.toJson() case final value?) 'delete': value,
+      if (instance.options?.toJson() case final value?) 'options': value,
+      if (instance.head?.toJson() case final value?) 'head': value,
+      if (instance.patch?.toJson() case final value?) 'patch': value,
+      if (instance.trace?.toJson() case final value?) 'trace': value,
+      if (instance.servers?.map((e) => e.toJson()).toList() case final value?)
+        'servers': value,
+      if (instance.parameters?.map((e) => e.toJson()).toList()
+          case final value?)
+        'parameters': value,
+      if (const _PathRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+    };
 
 _$RequestBodyImpl _$$RequestBodyImplFromJson(Map<String, dynamic> json) =>
     _$RequestBodyImpl(
@@ -852,22 +697,16 @@ _$RequestBodyImpl _$$RequestBodyImplFromJson(Map<String, dynamic> json) =>
       ref: const _RequestRefConverter().fromJson(json[r'$ref'] as String?),
     );
 
-Map<String, dynamic> _$$RequestBodyImplToJson(_$RequestBodyImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  writeNotNull('required', instance.required);
-  writeNotNull(
-      'content', instance.content?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(r'$ref', const _RequestRefConverter().toJson(instance.ref));
-  return val;
-}
+Map<String, dynamic> _$$RequestBodyImplToJson(_$RequestBodyImpl instance) =>
+    <String, dynamic>{
+      if (instance.description case final value?) 'description': value,
+      if (instance.required case final value?) 'required': value,
+      if (instance.content?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'content': value,
+      if (const _RequestRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+    };
 
 _$ResponseImpl _$$ResponseImplFromJson(Map<String, dynamic> json) =>
     _$ResponseImpl(
@@ -884,25 +723,21 @@ _$ResponseImpl _$$ResponseImplFromJson(Map<String, dynamic> json) =>
       ref: const _ResponseRefConverter().fromJson(json[r'$ref'] as String?),
     );
 
-Map<String, dynamic> _$$ResponseImplToJson(_$ResponseImpl instance) {
-  final val = <String, dynamic>{
-    'description': instance.description,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull(
-      'headers', instance.headers?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(
-      'content', instance.content?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull('links', instance.links?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull(r'$ref', const _ResponseRefConverter().toJson(instance.ref));
-  return val;
-}
+Map<String, dynamic> _$$ResponseImplToJson(_$ResponseImpl instance) =>
+    <String, dynamic>{
+      'description': instance.description,
+      if (instance.headers?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'headers': value,
+      if (instance.content?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'content': value,
+      if (instance.links?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'links': value,
+      if (const _ResponseRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+    };
 
 _$SchemaObjectImpl _$$SchemaObjectImplFromJson(Map<String, dynamic> json) =>
     _$SchemaObjectImpl(
@@ -912,6 +747,8 @@ _$SchemaObjectImpl _$$SchemaObjectImplFromJson(Map<String, dynamic> json) =>
       ref: const _SchemaRefConverter().fromJson(json[r'$ref'] as String?),
       allOf: _$JsonConverterFromJson<List<dynamic>, List<Schema>>(
           json['allOf'], const _SchemaListConverter().fromJson),
+      oneOf: _$JsonConverterFromJson<List<dynamic>, List<Schema>>(
+          json['oneOf'], const _SchemaListConverter().fromJson),
       anyOf: _$JsonConverterFromJson<List<dynamic>, List<Schema>>(
           json['anyOf'], const _SchemaListConverter().fromJson),
       required: (json['required'] as List<dynamic>?)
@@ -934,37 +771,37 @@ _$SchemaObjectImpl _$$SchemaObjectImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaObjectImplToJson(_$SchemaObjectImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  writeNotNull(
-      'allOf',
-      _$JsonConverterToJson<List<dynamic>, List<Schema>>(
-          instance.allOf, const _SchemaListConverter().toJson));
-  writeNotNull(
-      'anyOf',
-      _$JsonConverterToJson<List<dynamic>, List<Schema>>(
-          instance.anyOf, const _SchemaListConverter().toJson));
-  writeNotNull('required', instance.required);
-  writeNotNull('discriminator', instance.discriminator?.toJson());
-  writeNotNull('externalDocs', instance.externalDocs?.toJson());
-  writeNotNull('properties',
-      instance.properties?.map((k, e) => MapEntry(k, e.toJson())));
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('xml', instance.xml?.toJson());
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaObjectImplToJson(_$SchemaObjectImpl instance) =>
+    <String, dynamic>{
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      if (_$JsonConverterToJson<List<dynamic>, List<Schema>>(
+              instance.allOf, const _SchemaListConverter().toJson)
+          case final value?)
+        'allOf': value,
+      if (_$JsonConverterToJson<List<dynamic>, List<Schema>>(
+              instance.oneOf, const _SchemaListConverter().toJson)
+          case final value?)
+        'oneOf': value,
+      if (_$JsonConverterToJson<List<dynamic>, List<Schema>>(
+              instance.anyOf, const _SchemaListConverter().toJson)
+          case final value?)
+        'anyOf': value,
+      if (instance.required case final value?) 'required': value,
+      if (instance.discriminator?.toJson() case final value?)
+        'discriminator': value,
+      if (instance.externalDocs?.toJson() case final value?)
+        'externalDocs': value,
+      if (instance.properties?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'properties': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      'type': instance.$type,
+    };
 
 _$SchemaBooleanImpl _$$SchemaBooleanImplFromJson(Map<String, dynamic> json) =>
     _$SchemaBooleanImpl(
@@ -980,25 +817,18 @@ _$SchemaBooleanImpl _$$SchemaBooleanImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaBooleanImplToJson(_$SchemaBooleanImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('xml', instance.xml?.toJson());
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('example', instance.example);
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaBooleanImplToJson(_$SchemaBooleanImpl instance) =>
+    <String, dynamic>{
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (instance.example case final value?) 'example': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 _$SchemaStringImpl _$$SchemaStringImplFromJson(Map<String, dynamic> json) =>
     _$SchemaStringImpl(
@@ -1021,31 +851,27 @@ _$SchemaStringImpl _$$SchemaStringImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaStringImplToJson(_$SchemaStringImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('xml', instance.xml?.toJson());
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('format', _$StringFormatEnumMap[instance.format]);
-  writeNotNull('pattern', instance.pattern);
-  writeNotNull('example', instance.example);
-  writeNotNull('minLength', instance.minLength);
-  writeNotNull('maxLength', instance.maxLength);
-  writeNotNull('exclusiveMinimum', instance.exclusiveMinimum);
-  writeNotNull('exclusiveMaximum', instance.exclusiveMaximum);
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaStringImplToJson(_$SchemaStringImpl instance) =>
+    <String, dynamic>{
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (_$StringFormatEnumMap[instance.format] case final value?)
+        'format': value,
+      if (instance.pattern case final value?) 'pattern': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.minLength case final value?) 'minLength': value,
+      if (instance.maxLength case final value?) 'maxLength': value,
+      if (instance.exclusiveMinimum case final value?)
+        'exclusiveMinimum': value,
+      if (instance.exclusiveMaximum case final value?)
+        'exclusiveMaximum': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 const _$StringFormatEnumMap = {
   StringFormat.byte: 'byte',
@@ -1083,31 +909,27 @@ _$SchemaIntegerImpl _$$SchemaIntegerImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaIntegerImplToJson(_$SchemaIntegerImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('xml', instance.xml?.toJson());
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('format', _$IntegerFormatEnumMap[instance.format]);
-  writeNotNull('example', instance.example);
-  writeNotNull('minimum', instance.minimum);
-  writeNotNull('maximum', instance.maximum);
-  writeNotNull('exclusiveMinimum', instance.exclusiveMinimum);
-  writeNotNull('exclusiveMaximum', instance.exclusiveMaximum);
-  writeNotNull('multipleOf', instance.multipleOf);
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaIntegerImplToJson(_$SchemaIntegerImpl instance) =>
+    <String, dynamic>{
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (_$IntegerFormatEnumMap[instance.format] case final value?)
+        'format': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.minimum case final value?) 'minimum': value,
+      if (instance.maximum case final value?) 'maximum': value,
+      if (instance.exclusiveMinimum case final value?)
+        'exclusiveMinimum': value,
+      if (instance.exclusiveMaximum case final value?)
+        'exclusiveMaximum': value,
+      if (instance.multipleOf case final value?) 'multipleOf': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 const _$IntegerFormatEnumMap = {
   IntegerFormat.int32: 'int32',
@@ -1135,31 +957,27 @@ _$SchemaNumberImpl _$$SchemaNumberImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaNumberImplToJson(_$SchemaNumberImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('xml', instance.xml?.toJson());
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('format', _$NumberFormatEnumMap[instance.format]);
-  writeNotNull('example', instance.example);
-  writeNotNull('minimum', instance.minimum);
-  writeNotNull('maximum', instance.maximum);
-  writeNotNull('exclusiveMinimum', instance.exclusiveMinimum);
-  writeNotNull('exclusiveMaximum', instance.exclusiveMaximum);
-  writeNotNull('multipleOf', instance.multipleOf);
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaNumberImplToJson(_$SchemaNumberImpl instance) =>
+    <String, dynamic>{
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (_$NumberFormatEnumMap[instance.format] case final value?)
+        'format': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.minimum case final value?) 'minimum': value,
+      if (instance.maximum case final value?) 'maximum': value,
+      if (instance.exclusiveMinimum case final value?)
+        'exclusiveMinimum': value,
+      if (instance.exclusiveMaximum case final value?)
+        'exclusiveMaximum': value,
+      if (instance.multipleOf case final value?) 'multipleOf': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 const _$NumberFormatEnumMap = {
   NumberFormat.float: 'float',
@@ -1179,25 +997,18 @@ _$SchemaEnumImpl _$$SchemaEnumImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaEnumImplToJson(_$SchemaEnumImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('example', instance.example);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('enum', instance.values);
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaEnumImplToJson(_$SchemaEnumImpl instance) =>
+    <String, dynamic>{
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (instance.values case final value?) 'enum': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 _$SchemaArrayImpl _$$SchemaArrayImplFromJson(Map<String, dynamic> json) =>
     _$SchemaArrayImpl(
@@ -1216,28 +1027,21 @@ _$SchemaArrayImpl _$$SchemaArrayImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaArrayImplToJson(_$SchemaArrayImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('xml', instance.xml?.toJson());
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('example', instance.example);
-  writeNotNull('minItems', instance.minItems);
-  writeNotNull('maxItems', instance.maxItems);
-  val['items'] = instance.items.toJson();
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaArrayImplToJson(_$SchemaArrayImpl instance) =>
+    <String, dynamic>{
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (instance.example case final value?) 'example': value,
+      if (instance.minItems case final value?) 'minItems': value,
+      if (instance.maxItems case final value?) 'maxItems': value,
+      'items': instance.items.toJson(),
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 _$SchemaMapImpl _$$SchemaMapImplFromJson(Map<String, dynamic> json) =>
     _$SchemaMapImpl(
@@ -1254,26 +1058,20 @@ _$SchemaMapImpl _$$SchemaMapImplFromJson(Map<String, dynamic> json) =>
       $type: json['type'] as String?,
     );
 
-Map<String, dynamic> _$$SchemaMapImplToJson(_$SchemaMapImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('xml', instance.xml?.toJson());
-  writeNotNull('title', instance.title);
-  writeNotNull('description', instance.description);
-  writeNotNull('default', instance.defaultValue);
-  writeNotNull('nullable', instance.nullable);
-  writeNotNull('example', instance.example);
-  writeNotNull('additionalProperties', _toMapProps(instance.valueSchema));
-  writeNotNull(r'$ref', const _SchemaRefConverter().toJson(instance.ref));
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$SchemaMapImplToJson(_$SchemaMapImpl instance) =>
+    <String, dynamic>{
+      if (instance.xml?.toJson() case final value?) 'xml': value,
+      if (instance.title case final value?) 'title': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.defaultValue case final value?) 'default': value,
+      if (instance.nullable case final value?) 'nullable': value,
+      if (instance.example case final value?) 'example': value,
+      if (_toMapProps(instance.valueSchema) case final value?)
+        'additionalProperties': value,
+      if (const _SchemaRefConverter().toJson(instance.ref) case final value?)
+        r'$ref': value,
+      'type': instance.$type,
+    };
 
 _$SecuritySchemeApiKeyImpl _$$SecuritySchemeApiKeyImplFromJson(
         Map<String, dynamic> json) =>
@@ -1285,22 +1083,13 @@ _$SecuritySchemeApiKeyImpl _$$SecuritySchemeApiKeyImplFromJson(
     );
 
 Map<String, dynamic> _$$SecuritySchemeApiKeyImplToJson(
-    _$SecuritySchemeApiKeyImpl instance) {
-  final val = <String, dynamic>{
-    'name': instance.name,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  val['in'] = _$ApiKeyLocationEnumMap[instance.location]!;
-  val['type'] = instance.$type;
-  return val;
-}
+        _$SecuritySchemeApiKeyImpl instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      if (instance.description case final value?) 'description': value,
+      'in': _$ApiKeyLocationEnumMap[instance.location]!,
+      'type': instance.$type,
+    };
 
 const _$ApiKeyLocationEnumMap = {
   ApiKeyLocation.query: 'query',
@@ -1318,22 +1107,13 @@ _$SecuritySchemeHttpImpl _$$SecuritySchemeHttpImplFromJson(
     );
 
 Map<String, dynamic> _$$SecuritySchemeHttpImplToJson(
-    _$SecuritySchemeHttpImpl instance) {
-  final val = <String, dynamic>{
-    'scheme': _$HttpSecuritySchemeEnumMap[instance.scheme]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('bearerFormat', instance.bearerFormat);
-  writeNotNull('description', instance.description);
-  val['type'] = instance.$type;
-  return val;
-}
+        _$SecuritySchemeHttpImpl instance) =>
+    <String, dynamic>{
+      'scheme': _$HttpSecuritySchemeEnumMap[instance.scheme]!,
+      if (instance.bearerFormat case final value?) 'bearerFormat': value,
+      if (instance.description case final value?) 'description': value,
+      'type': instance.$type,
+    };
 
 const _$HttpSecuritySchemeEnumMap = {
   HttpSecurityScheme.basic: 'basic',
@@ -1348,19 +1128,11 @@ _$SecuritySchemeMutualTLSImpl _$$SecuritySchemeMutualTLSImplFromJson(
     );
 
 Map<String, dynamic> _$$SecuritySchemeMutualTLSImplToJson(
-    _$SecuritySchemeMutualTLSImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  val['type'] = instance.$type;
-  return val;
-}
+        _$SecuritySchemeMutualTLSImpl instance) =>
+    <String, dynamic>{
+      if (instance.description case final value?) 'description': value,
+      'type': instance.$type,
+    };
 
 _$SecuritySchemeOauth2Impl _$$SecuritySchemeOauth2ImplFromJson(
         Map<String, dynamic> json) =>
@@ -1371,20 +1143,12 @@ _$SecuritySchemeOauth2Impl _$$SecuritySchemeOauth2ImplFromJson(
     );
 
 Map<String, dynamic> _$$SecuritySchemeOauth2ImplToJson(
-    _$SecuritySchemeOauth2Impl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  val['flows'] = instance.flows.toJson();
-  val['type'] = instance.$type;
-  return val;
-}
+        _$SecuritySchemeOauth2Impl instance) =>
+    <String, dynamic>{
+      if (instance.description case final value?) 'description': value,
+      'flows': instance.flows.toJson(),
+      'type': instance.$type,
+    };
 
 _$SecuritySchemeOpenIdConnectImpl _$$SecuritySchemeOpenIdConnectImplFromJson(
         Map<String, dynamic> json) =>
@@ -1395,20 +1159,12 @@ _$SecuritySchemeOpenIdConnectImpl _$$SecuritySchemeOpenIdConnectImplFromJson(
     );
 
 Map<String, dynamic> _$$SecuritySchemeOpenIdConnectImplToJson(
-    _$SecuritySchemeOpenIdConnectImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  val['openIdConnectUrl'] = instance.url;
-  val['type'] = instance.$type;
-  return val;
-}
+        _$SecuritySchemeOpenIdConnectImpl instance) =>
+    <String, dynamic>{
+      if (instance.description case final value?) 'description': value,
+      'openIdConnectUrl': instance.url,
+      'type': instance.$type,
+    };
 
 _$ServerImpl _$$ServerImplFromJson(Map<String, dynamic> json) => _$ServerImpl(
       url: json['url'] as String?,
@@ -1419,21 +1175,14 @@ _$ServerImpl _$$ServerImplFromJson(Map<String, dynamic> json) => _$ServerImpl(
       ),
     );
 
-Map<String, dynamic> _$$ServerImplToJson(_$ServerImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('url', instance.url);
-  writeNotNull('description', instance.description);
-  writeNotNull(
-      'variables', instance.variables?.map((k, e) => MapEntry(k, e.toJson())));
-  return val;
-}
+Map<String, dynamic> _$$ServerImplToJson(_$ServerImpl instance) =>
+    <String, dynamic>{
+      if (instance.url case final value?) 'url': value,
+      if (instance.description case final value?) 'description': value,
+      if (instance.variables?.map((k, e) => MapEntry(k, e.toJson()))
+          case final value?)
+        'variables': value,
+    };
 
 _$ServerVariableImpl _$$ServerVariableImplFromJson(Map<String, dynamic> json) =>
     _$ServerVariableImpl(
@@ -1444,20 +1193,12 @@ _$ServerVariableImpl _$$ServerVariableImplFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$$ServerVariableImplToJson(
-    _$ServerVariableImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('enum', instance.enumValue);
-  val['default'] = instance.defaultValue;
-  writeNotNull('description', instance.description);
-  return val;
-}
+        _$ServerVariableImpl instance) =>
+    <String, dynamic>{
+      if (instance.enumValue case final value?) 'enum': value,
+      'default': instance.defaultValue,
+      if (instance.description case final value?) 'description': value,
+    };
 
 _$TagImpl _$$TagImplFromJson(Map<String, dynamic> json) => _$TagImpl(
       name: json['name'] as String,
@@ -1467,21 +1208,12 @@ _$TagImpl _$$TagImplFromJson(Map<String, dynamic> json) => _$TagImpl(
           : ExternalDocs.fromJson(json['externalDocs'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$TagImplToJson(_$TagImpl instance) {
-  final val = <String, dynamic>{
-    'name': instance.name,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('description', instance.description);
-  writeNotNull('externalDocs', instance.externalDocs?.toJson());
-  return val;
-}
+Map<String, dynamic> _$$TagImplToJson(_$TagImpl instance) => <String, dynamic>{
+      'name': instance.name,
+      if (instance.description case final value?) 'description': value,
+      if (instance.externalDocs?.toJson() case final value?)
+        'externalDocs': value,
+    };
 
 _$XmlImpl _$$XmlImplFromJson(Map<String, dynamic> json) => _$XmlImpl(
       name: json['name'] as String?,
@@ -1491,19 +1223,10 @@ _$XmlImpl _$$XmlImplFromJson(Map<String, dynamic> json) => _$XmlImpl(
       wrapped: json['wrapped'] as bool?,
     );
 
-Map<String, dynamic> _$$XmlImplToJson(_$XmlImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  writeNotNull('namespace', instance.namespace);
-  writeNotNull('prefix', instance.prefix);
-  writeNotNull('attribute', instance.attribute);
-  writeNotNull('wrapped', instance.wrapped);
-  return val;
-}
+Map<String, dynamic> _$$XmlImplToJson(_$XmlImpl instance) => <String, dynamic>{
+      if (instance.name case final value?) 'name': value,
+      if (instance.namespace case final value?) 'namespace': value,
+      if (instance.prefix case final value?) 'prefix': value,
+      if (instance.attribute case final value?) 'attribute': value,
+      if (instance.wrapped case final value?) 'wrapped': value,
+    };

--- a/lib/src/open_api/parameter.dart
+++ b/lib/src/open_api/parameter.dart
@@ -27,7 +27,7 @@ class Parameter with _$Parameter {
     String? example,
     required Schema schema,
     @JsonKey(name: '\$ref') @_ParamRefConverter() String? ref,
-  }) = _ParameterCookie;
+  }) = ParameterCookie;
 
   // ------------------------------------------
   // FACTORY: Parameter.header
@@ -47,7 +47,7 @@ class Parameter with _$Parameter {
     String? example,
     required Schema schema,
     @JsonKey(name: '\$ref') @_ParamRefConverter() String? ref,
-  }) = _ParameterHeader;
+  }) = ParameterHeader;
 
   // ------------------------------------------
   // FACTORY: Parameter.query
@@ -67,7 +67,7 @@ class Parameter with _$Parameter {
     String? example,
     required Schema schema,
     @JsonKey(name: '\$ref') @_ParamRefConverter() String? ref,
-  }) = _ParameterQuery;
+  }) = ParameterQuery;
 
   // ------------------------------------------
   // FACTORY: Parameter.path
@@ -86,7 +86,7 @@ class Parameter with _$Parameter {
     String? example,
     Schema? schema,
     @JsonKey(name: '\$ref') @_ParamRefConverter() String? ref,
-  }) = _ParameterPath;
+  }) = ParameterPath;
 
   // ------------------------------------------
   // FACTORY: Parameter.fromJson

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -56,6 +56,9 @@ class Schema with _$Schema {
     /// The allOf definition
     @_SchemaListConverter() List<Schema>? allOf,
 
+    /// The allOf definition
+    @_SchemaListConverter() List<Schema>? oneOf,
+
     /// The anyOf definition
     @_SchemaListConverter() List<Schema>? anyOf,
 
@@ -81,7 +84,7 @@ class Schema with _$Schema {
 
     /// Adds additional metadata to describe the XML representation of this property.
     Xml? xml,
-  }) = _SchemaObject;
+  }) = SchemaObject;
 
   /// Get the schema type based on the union type
   SchemaType get type {
@@ -109,7 +112,7 @@ class Schema with _$Schema {
     bool? nullable,
     bool? example,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaBoolean;
+  }) = SchemaBoolean;
 
   // ------------------------------------------
   // FACTORY: Schema.string
@@ -130,7 +133,7 @@ class Schema with _$Schema {
     bool? exclusiveMinimum,
     bool? exclusiveMaximum,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaString;
+  }) = SchemaString;
 
   // ------------------------------------------
   // FACTORY: Schema.integer
@@ -152,7 +155,7 @@ class Schema with _$Schema {
     bool? exclusiveMaximum,
     @JsonKey(fromJson: _fromJsonInt) int? multipleOf,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaInteger;
+  }) = SchemaInteger;
 
   // ------------------------------------------
   // FACTORY: Schema.number
@@ -174,7 +177,7 @@ class Schema with _$Schema {
     bool? exclusiveMaximum,
     @JsonKey(fromJson: _fromJsonDouble) double? multipleOf,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaNumber;
+  }) = SchemaNumber;
 
   // ------------------------------------------
   // FACTORY: Schema.enumeration
@@ -189,7 +192,7 @@ class Schema with _$Schema {
     @JsonKey(includeToJson: false, includeFromJson: false) String? unknownValue,
     @JsonKey(name: 'enum') List<String>? values,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaEnum;
+  }) = SchemaEnum;
 
   // ------------------------------------------
   // FACTORY: Schema.array
@@ -207,7 +210,7 @@ class Schema with _$Schema {
     @JsonKey(fromJson: _fromJsonInt) int? maxItems,
     required Schema items,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaArray;
+  }) = SchemaArray;
 
   // ------------------------------------------
   // FACTORY: Schema.map
@@ -227,7 +230,7 @@ class Schema with _$Schema {
         fromJson: _fromMapProps)
     Schema? valueSchema,
     @JsonKey(name: '\$ref') @_SchemaRefConverter() String? ref,
-  }) = _SchemaMap;
+  }) = SchemaMap;
 
   // ------------------------------------------
   // FACTORY: Schema.fromJson
@@ -264,7 +267,7 @@ class Schema with _$Schema {
     return map(
       object: (s) {
         // Handle List and Map defined as typedefs
-        if (sRef is _SchemaArray || sRef is _SchemaMap) {
+        if (sRef is SchemaArray || sRef is SchemaMap) {
           return copyWith(
             title: s.title ?? sRef.title,
             description: s.description ?? sRef.description,
@@ -272,7 +275,7 @@ class Schema with _$Schema {
           );
         }
 
-        return (sRef as _SchemaObject).copyWith(
+        return (sRef as SchemaObject).copyWith(
           ref: ref,
           title: s.title ?? sRef.title,
           description: s.description ?? sRef.description,
@@ -281,19 +284,19 @@ class Schema with _$Schema {
         );
       },
       boolean: (s) {
-        return (sRef as _SchemaBoolean).copyWith(ref: ref);
+        return (sRef as SchemaBoolean).copyWith(ref: ref);
       },
       string: (s) {
-        return (sRef as _SchemaString).copyWith(ref: ref);
+        return (sRef as SchemaString).copyWith(ref: ref);
       },
       integer: (s) {
-        return (sRef as _SchemaInteger).copyWith(ref: ref);
+        return (sRef as SchemaInteger).copyWith(ref: ref);
       },
       number: (s) {
-        return (sRef as _SchemaNumber).copyWith(ref: ref);
+        return (sRef as SchemaNumber).copyWith(ref: ref);
       },
       enumeration: (s) {
-        return (sRef as _SchemaEnum).copyWith(
+        return (sRef as SchemaEnum).copyWith(
           ref: ref,
           title: s.title ?? sRef.title,
           description: s.description ?? sRef.description,
@@ -303,10 +306,10 @@ class Schema with _$Schema {
         );
       },
       array: (s) {
-        return (sRef as _SchemaArray).copyWith(ref: ref);
+        return (sRef as SchemaArray).copyWith(ref: ref);
       },
       map: (s) {
-        return (sRef as _SchemaMap).copyWith(
+        return (sRef as SchemaMap).copyWith(
           ref: ref,
         );
       },
@@ -454,7 +457,7 @@ class _SchemaConverter implements JsonConverter<Schema, Map<String, dynamic>> {
   Schema fromJson(Map<String, dynamic> json) {
     return fromJsonWithLogging(json, (json) {
       if (json.containsKey('enum') && json['enum'].isNotEmpty) {
-        return _SchemaEnum.fromJson(json);
+        return SchemaEnum.fromJson(json);
       } else {
         return Schema.fromJson(json);
       }


### PR DESCRIPTION
Thanks for this great package. It seems one of the most complete in terms of parsing and working with OpenApi specs.

I'm developing my own generators and using this package primarily for parsing. I hope you're open to merging these small changes.

- adds oneOf field support
- makes some of the freezed union subtypes public. This allows me to differentiate on the type of schema or parameter by type.