### PR TITLE
fix: schema aliases can now be dereferenced correctly

### DIFF
--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -663,6 +663,7 @@ class SchemaGenerator extends BaseGenerator {
     required Schema property,
     required bool required,
   }) {
+    property = property.dereference(components: spec.components?.schemas);
     // The validation to perform for this property
     SchemaValidation? validation;
 
@@ -710,10 +711,6 @@ class SchemaGenerator extends BaseGenerator {
 
     property.map(
       object: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              object: (s) => s,
-              orElse: () => p,
-            );
         bool hasDefault = p.defaultValue != null;
 
         String customConverter = '';
@@ -816,19 +813,11 @@ class SchemaGenerator extends BaseGenerator {
         file.writeAsStringSync(c, mode: FileMode.append);
       },
       boolean: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              boolean: (s) => s,
-              orElse: () => p,
-            );
         var (c, nullable) = propHeader(p.defaultValue, p.description);
         c += "bool ${nullable ? '?' : ''} $name,\n\n";
         file.writeAsStringSync(c, mode: FileMode.append);
       },
       string: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              string: (s) => s,
-              orElse: () => p,
-            );
         var (c, nullable) = propHeader(p.defaultValue, p.description);
         c += "String ${nullable ? '?' : ''} $name,\n\n";
         file.writeAsStringSync(c, mode: FileMode.append);
@@ -843,10 +832,6 @@ class SchemaGenerator extends BaseGenerator {
         );
       },
       integer: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              integer: (s) => s,
-              orElse: () => p,
-            );
         var (c, nullable) = propHeader(p.defaultValue, p.description);
         c += "int ${nullable ? '?' : ''} $name,\n\n";
         file.writeAsStringSync(c, mode: FileMode.append);
@@ -864,10 +849,6 @@ class SchemaGenerator extends BaseGenerator {
         );
       },
       number: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              number: (s) => s,
-              orElse: () => p,
-            );
         var (c, nullable) = propHeader(p.defaultValue, p.description);
         c += "double ${nullable ? '?' : ''} $name,\n\n";
         file.writeAsStringSync(c, mode: FileMode.append);
@@ -885,20 +866,12 @@ class SchemaGenerator extends BaseGenerator {
         );
       },
       array: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              array: (s) => s,
-              orElse: () => p,
-            );
         var (c, nullable) = propHeader(p.defaultValue, p.description);
         var itemType = p.items.toDartType(unions: _unions);
         c += "List<$itemType> ${nullable ? '?' : ''} $name,\n\n";
         file.writeAsStringSync(c, mode: FileMode.append);
       },
       map: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              map: (s) => s,
-              orElse: () => p,
-            );
         // If map is not required and is not explicitly nullable, default to empty map
         if (!required && p.nullable != true) {
           p = p.copyWith(defaultValue: {}, nullable: false);
@@ -910,11 +883,6 @@ class SchemaGenerator extends BaseGenerator {
         file.writeAsStringSync(c, mode: FileMode.append);
       },
       enumeration: (p) {
-        p = p.dereference(components: spec.components?.schemas).maybeMap(
-              enumeration: (s) => s,
-              orElse: () => p,
-            );
-
         bool hasDefault = p.defaultValue != null;
         bool nullable = !hasDefault && !required || p.nullable == true;
         String description = p.description?.trim() ?? '';

--- a/lib/src/open_api/index.dart
+++ b/lib/src/open_api/index.dart
@@ -59,6 +59,7 @@ bool _checkReferenceTypes(name, ref, self) {
       return true;
     } else if (self is SchemaObject) {
       // Reference types can be different if the reference is a SchemaObject
+      // should this return true?
       return false;
     } else {
       throw Exception(

--- a/lib/src/open_api/index.dart
+++ b/lib/src/open_api/index.dart
@@ -59,8 +59,7 @@ bool _checkReferenceTypes(name, ref, self) {
       return true;
     } else if (self is SchemaObject) {
       // Reference types can be different if the reference is a SchemaObject
-      // should this return true?
-      return false;
+      return true;
     } else {
       throw Exception(
         "\n\n'$name' type mismatch\n\nSchema component type: $sRefType\n\nUser specified reference type: $sType\n",

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -267,21 +267,47 @@ class Schema with _$Schema {
 
     return map(
       object: (s) {
-        // Handle List and Map defined as typedefs
-        if (sRef is SchemaArray || sRef is SchemaMap) {
-          return copyWith(
-            title: s.title ?? sRef.title,
-            description: s.description ?? sRef.description,
-            nullable: s.nullable ?? sRef.nullable,
-          );
-        }
-
-        return (sRef as SchemaObject).copyWith(
-          ref: ref,
-          title: s.title ?? sRef.title,
-          description: s.description ?? sRef.description,
-          defaultValue: s.defaultValue ?? sRef.defaultValue,
-          nullable: s.nullable ?? sRef.nullable,
+        return sRef.maybeMap(
+          array: (a) {
+            return copyWith(
+              title: s.title ?? sRef.title,
+              description: s.description ?? sRef.description,
+              nullable: s.nullable ?? sRef.nullable,
+            );
+          },
+          map: (m) {
+            return copyWith(
+              title: s.title ?? sRef.title,
+              description: s.description ?? sRef.description,
+              nullable: s.nullable ?? sRef.nullable,
+            );
+          },
+          enumeration: (e){
+            return e.copyWith(
+              ref: ref,
+              title: s.title ?? sRef.title,
+              description: s.description ?? sRef.description,
+              defaultValue: s.defaultValue ?? sRef.defaultValue,
+              nullable: s.nullable ?? sRef.nullable,
+            );
+          },
+          object: (o) {
+            return o.copyWith(
+              ref: ref,
+              title: s.title ?? sRef.title,
+              description: s.description ?? sRef.description,
+              defaultValue: s.defaultValue ?? sRef.defaultValue,
+              nullable: s.nullable ?? sRef.nullable,
+            );
+          },
+          orElse: () {
+            return sRef.copyWith(
+              // ref: ref,
+              title: s.title ?? sRef.title,
+              description: s.description ?? sRef.description,
+              nullable: s.nullable ?? sRef.nullable,
+            );
+          },
         );
       },
       boolean: (s) {

--- a/lib/src/open_api/schema.dart
+++ b/lib/src/open_api/schema.dart
@@ -257,6 +257,7 @@ class Schema with _$Schema {
       );
     }
 
+    // schema alias issue is caused by _checkReferenceTypes returning false
     final isMatch = _checkReferenceTypes(ref, sRef, this);
 
     if (!isMatch) {

--- a/test/generation/alias.json
+++ b/test/generation/alias.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "schema",
+    "description": "Schema",
+    "version": "1.0.0"
+  },
+  "paths": {
+  },
+  "components": {
+    "schemas": {
+      "MyAlias": {
+        "type": "string"
+      },
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "myField": {
+            "$ref": "#/components/schemas/MyAlias"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/generation/ref_alias_test.dart
+++ b/test/generation/ref_alias_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:openapi_spec/openapi_spec.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final tmp = Directory(
+    p.join('test', 'tmp', 'generation'),
+  );
+
+  final truthJson = p.join('test', 'generation', 'alias.json');
+
+  late OpenApi spec;
+
+  void createTmpDir() {
+    if (tmp.existsSync()) {
+      tmp.deleteSync(recursive: true);
+    }
+    tmp.createSync(recursive: true);
+  }
+
+  group('Alias', () {
+    setUp(() {
+      spec = OpenApi.fromFile(source: truthJson);
+      createTmpDir();
+    });
+
+    /// Test schema generation (single file)
+    test('Can dereference ref alias', () async {
+      final model = spec.components!.schemas!["MyObject"]! as SchemaObject;
+      final field = model.properties!["myField"];
+      expect(field!.ref, equals("MyAlias"));
+
+      final dereferenced = field.dereference(components: spec.components!.schemas);
+
+      // the deferenced schema should now be a string
+      expect(dereferenced.type, equals(SchemaType.string));
+      expect(dereferenced.ref, isNull);
+    });
+
+    test('Generate Schema Code', () async {
+      final dir = tmp.createTempSync();
+      await spec.generate(
+        package: 'alias',
+        quiet: true,
+        replace: true,
+        destination: dir.path,
+        schemaOptions: SchemaGeneratorOptions(
+          singleFile: true,
+        ),
+      );
+      final genDir = Directory(p.join(dir.path, 'schema'));
+      final genFiles = genDir.listSync();
+      expect(genFiles.length, 1);
+      expect(File(p.joinAll([genDir.path, "schema.dart"])).readAsStringSync(), equals(r'''
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'schema.g.dart';
+part 'schema.freezed.dart';
+
+// ==========================================
+// CLASS: MyObject
+// ==========================================
+
+/// No Description
+@freezed
+class MyObject with _$MyObject {
+  const MyObject._();
+
+  /// Factory constructor for MyObject
+  const factory MyObject({
+    /// No Description
+    @JsonKey(includeIfNull: false) String? myField,
+  }) = _MyObject;
+
+  /// Object construction from a JSON representation
+  factory MyObject.fromJson(Map<String, dynamic> json) =>
+      _$MyObjectFromJson(json);
+
+  /// List of all property names of schema
+  static const List<String> propertyNames = ['myField'];
+
+  /// Perform validations on the schema property values
+  String? validateSchema() {
+    return null;
+  }
+
+  /// Map representation of object (not serialized)
+  Map<String, dynamic> toMap() {
+    return {
+      'myField': myField,
+    };
+  }
+}
+'''));
+    });
+  });
+}

--- a/test/generation/ref_alias_test.dart
+++ b/test/generation/ref_alias_test.dart
@@ -34,7 +34,7 @@ void main() {
 
       final dereferenced = field.dereference(components: spec.components!.schemas);
 
-      // the deferenced schema should now be a string
+      // the dereferenced schema should now be a string
       expect(dereferenced.type, equals(SchemaType.string));
       expect(dereferenced.ref, isNull);
     });


### PR DESCRIPTION
This PR fixes an issue where schemas that alias a primitive type schema such as string or int cannot be dereferenced correctly.