### PR TITLE
Closes #79 Fix dereference of alias schemas

### DIFF
--- a/lib/src/generators/schema.dart
+++ b/lib/src/generators/schema.dart
@@ -160,6 +160,13 @@ class SchemaGenerator extends BaseGenerator {
         enumeration: (schema) {
           _writeEnumeration(name: name, schema: schema);
         },
+        string: (value) {
+          _writeTypedef(
+            name: name,
+            description: value.description,
+            def: 'String',
+          );
+        },
         array: (schema) {
           final iType = schema.items.toDartType();
           _writeTypedef(

--- a/test/misc/misc.json
+++ b/test/misc/misc.json
@@ -31,6 +31,12 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
     "schemas": {
       "MapResult": {
         "properties": {},
@@ -38,6 +44,17 @@
         "type": "object",
         "title": "MapResult",
         "description": "A MapResult"
+      },
+      "StringAlias": {
+        "type": "string"
+      },
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "myField": {
+            "$ref": "#/components/schemas/StringAlias"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #79 Where `String` schema alias was not being properly written. For the following schema:

```json
"schemas": {
  "StringAlias": {
    "type": "string"
  },
  "MyObject": {
    "type": "object",
    "properties": {
      "myField": {
        "$ref": "#/components/schemas/StringAlias"
      }
    }
  }
}
```

The generator now properly creates the expected types:

```dart
typedef StringAlias = String;
```

```dart
@freezed
class MyObject with _$MyObject {
  const MyObject._();

  /// Factory constructor for MyObject
  const factory MyObject({
    /// No Description
    @JsonKey(includeIfNull: false) StringAlias? myField,
  }) = _MyObject;

  /// Object construction from a JSON representation
  factory MyObject.fromJson(Map<String, dynamic> json) =>
      _$MyObjectFromJson(json);

  /// List of all property names of schema
  static const List<String> propertyNames = ['myField'];

  /// Perform validations on the schema property values
  String? validateSchema() {
    return null;
  }

  /// Map representation of object (not serialized)
  Map<String, dynamic> toMap() {
    return {
      'myField': myField,
    };
  }
}
```

To run this test and inspect the generated code:

```
make test TEST_ARGS="-n Misc"
```